### PR TITLE
Replace addon signals

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,6 @@
 <addon id="service.upnext" name="Up Next" provider-name="im85288" version="0.0.3">
     <requires>
         <import addon="xbmc.python" version="2.20.0"/>
-        <import addon="script.module.addon.signals" version="0.0.1"/>
         <import addon="script.module.requests" version="2.9.1" />
         <import addon="script.module.simplejson" version="3.3.0"/>
     </requires>

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -1,6 +1,5 @@
 import xbmc
 import resources.lib.utils as utils
-import AddonSignals
 from resources.lib.upnext import UpNext
 from resources.lib.stillwatching import StillWatching
 import sys
@@ -25,7 +24,7 @@ class Player(xbmc.Player):
         self.__dict__ = self._shared_state
         self.logMsg("Starting playback monitor service", 1)
         self.setupFromSettings()
-        AddonSignals.registerSlot('upnextprovider', 'upnext_data', self.addon_data_received)
+        xbmc.Player.__init__(self)
 
     def logMsg(self, msg, lvl=1):
         self.className = self.__class__.__name__
@@ -335,7 +334,7 @@ class Player(xbmc.Player):
             if (shouldPlayDefault and self.playMode == "0") or (shouldPlayNonDefault and self.playMode == "1"):
                 self.logMsg("playing media episode id %s" % str(episodeid), 2)
                 # Signal to trakt previous episode watched
-                AddonSignals.sendSignal("NEXTUPWATCHEDSIGNAL", {'episodeid': self.currentepisodeid})
+                utils.event("NEXTUPWATCHEDSIGNAL", {'episodeid': self.currentepisodeid})
 
                 # Play media
                 if not self.addon_data:
@@ -343,8 +342,8 @@ class Player(xbmc.Player):
                         '{ "jsonrpc": "2.0", "id": 0, "method": "Player.Open", '
                         '"params": { "item": {"episodeid": ' + str(episode["episodeid"]) + '} } }')
                 else:
-                    self.logMsg("sending data to addon to play:  %s " % str(episode["playinfo"]), 2)
-                    AddonSignals.sendSignal("play_action", episode["playinfo"], source_id=episode["id"])
+                    self.logMsg("sending data to addon to play:  %s " % str(self.addon_data['play_info']), 2)
+                    utils.event(self.addon_data['id'], self.addon_data['play_info'], "upnextprovider")
 
 
     def developerPlayPlayback(self):

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -2,6 +2,7 @@ import xbmc
 import xbmcgui
 import xbmcaddon
 import inspect
+import binascii
 import sys
 if sys.version_info < (2, 7):
     import simplejson as json
@@ -76,6 +77,21 @@ def settings(setting, value=None):
             result = result in ("true", "1")
 
         return result
+
+def event(method, data=None, source_id=None):
+
+    ''' Data is a dictionary.
+    '''
+    data = data or {}
+    source_id = source_id or xbmcaddon.Addon().getAddonInfo('id')
+    xbmc.executebuiltin('NotifyAll(%s, %s, %s)' % (source_id, method, '\\"[\\"{0}\\"]\\"'.format(binascii.hexlify(json.dumps(data)))))
+
+def decode_data(data):
+
+    data = json.loads(data)
+
+    if data:
+        return json.loads(binascii.unhexlify(data[0]))
 
 
 def logMsg(title, msg, level=1):

--- a/service.py
+++ b/service.py
@@ -9,7 +9,7 @@ sys.path.append(BASE_RESOURCE_PATH)
 import resources.lib.utils as utils
 from resources.lib.player import Player
 
-class Service():
+class Service(xbmc.Monitor):
 
     def __init__(self, *args):
         self.logMsg("Starting UpNext Service", 0)
@@ -17,24 +17,28 @@ class Service():
         self.logMsg("KODI Version: %s" % xbmc.getInfoLabel("System.BuildVersion"), 0)
         self.logMsg("%s Version: %s" % (utils.addon_name(), utils.addon_version()), 0)
 
+        xbmc.Monitor.__init__(self)
+
     def logMsg(self, msg, lvl=1):
         class_name = self.__class__.__name__
         utils.logMsg("%s %s" % (utils.addon_name(), class_name), str(msg), int(lvl))
 
     def ServiceEntryPoint(self):
-        player = Player()
-        monitor = xbmc.Monitor()
+
+        self.player = Player()
         last_file = None
-        while not monitor.abortRequested():
+
+        while not self.abortRequested():
             # check every 1 sec
-            if monitor.waitForAbort(1):
+            if self.waitForAbort(1):
                 # Abort was requested while waiting. We should exit
                 break
-            if xbmc.Player().isPlaying():
+            if self.player.isPlaying():
+
                 try:
-                    play_time = xbmc.Player().getTime()
-                    total_time = xbmc.Player().getTotalTime()
-                    current_file = xbmc.Player().getPlayingFile()
+                    play_time = self.player.getTime()
+                    total_time = self.player.getTotalTime()
+                    current_file = self.player.getPlayingFile()
                     notification_time = utils.settings("autoPlaySeasonTime")
                     up_next_disabled = utils.settings("disableNextUp") == "true"
                     if utils.window("PseudoTVRunning") != "True" and not up_next_disabled and total_time > 300:
@@ -42,13 +46,23 @@ class Service():
                                         last_file is None or last_file != current_file)) and total_time != 0:
                             last_file = current_file
                             self.logMsg("Calling autoplayback totaltime - playtime is %s" % (total_time - play_time), 2)
-                            player.autoPlayPlayback()
+                            self.player.autoPlayPlayback()
                             self.logMsg("Up Next style autoplay succeeded.", 2)
 
                 except Exception as e:
                     self.logMsg("Exception in Playback Monitor Service: %s" % e)
 
         self.logMsg("======== STOP %s ========" % utils.addon_name(), 0)
+
+    def onNotification(self, sender, method, data):
+
+        if method.split('.')[1].lower() != 'upnext_data': # method looks like Other.upnext_data
+            return
+
+        data = utils.decode_data(data)
+        data['id'] = "%s_play_action" % str(sender)
+
+        self.player.addon_data_received(data)
 
 # start the service
 Service().ServiceEntryPoint()


### PR DESCRIPTION
UpNext will now listen to method "upnext_data" regardless of sender. It will send notification to addons using sender "upnextprovider" and the method "original sender's value" + "_play_action" (i.e. "embycon_play_action". That is what addons should listen to.