### PR TITLE
Reset last_file and data upon user stopping playback

### DIFF
--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -18,7 +18,7 @@ class Monitor(xbmc.Monitor):
         utils.log("%s %s" % (utils.addon_name(), class_name), str(msg), int(lvl))
 
     def run(self):
-        last_file = None
+
         while not self.abortRequested():
             # check every 1 sec
             if self.waitForAbort(1):
@@ -28,13 +28,14 @@ class Monitor(xbmc.Monitor):
                 try:
                     play_time = self.player.getTime()
                     total_time = self.player.getTotalTime()
+                    last_file = self.player.get_last_file()
                     current_file = self.player.getPlayingFile()
                     notification_time = self.api.notification_time()
                     up_next_disabled = utils.settings("disableNextUp") == "true"
                     if utils.window("PseudoTVRunning") != "True" and not up_next_disabled and total_time > 300:
                         if (total_time - play_time <= int(notification_time) and (
                                 last_file is None or last_file != current_file)) and total_time != 0:
-                            last_file = current_file
+                            self.player.set_last_file(current_file)
                             self.log("Calling autoplayback totaltime - playtime is %s" % (total_time - play_time), 2)
                             self.playback_manager.launch_up_next()
                             self.log("Up Next style autoplay succeeded.", 2)

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -2,17 +2,32 @@ import xbmc
 import resources.lib.utils as utils
 from resources.lib.api import Api
 from resources.lib.developer import Developer
+from resources.lib.state import State
 
 
 # service class for playback monitoring
 class Player(xbmc.Player):
+	last_file = None
+
     def __init__(self):
         self.api = Api()
         self.developer = Developer()
         xbmc.Player.__init__(self)
+
+    def set_last_file(self, file):
+        self.last_file = file
+
+    def get_last_file(self):
+        return self.last_file
 
     def onPlayBackStarted(self):
         # Will be called when kodi starts playing a file
         self.api.reset_addon_data()
         if utils.settings("developerMode") == "true":
             self.developer.developer_play_back()
+
+    def onPlayBackStopped(self):
+        # Will be called when user stops playing a file.
+        self.last_file = None
+        self.api.reset_addon_data()
+        State() # reset state


### PR DESCRIPTION
This fixes the scenario where user starts playing a file, stops before last_file gets updated in up next on the next episode. Then users plays the same file, leaving last_file outdated and preventing the dialog from showing up again. 

While the up next dialog is displayed, this will prevent a user manually stopping playback from triggering up next, data will be cleared.