### PR TITLE
Fix dialog not showing up

### DIFF
--- a/resources/lib/playbackManager.py
+++ b/resources/lib/playbackManager.py
@@ -30,6 +30,7 @@ class PlaybackManager:
             return
         self.log("episode details %s" % json.dumps(episode), 2)
         self.launch_popup(episode)
+        self.api.reset_addon_data()
 
     def launch_popup(self, episode):
         episode_id = episode["episodeid"]

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -7,7 +7,7 @@ from resources.lib.state import State
 
 # service class for playback monitoring
 class Player(xbmc.Player):
-        last_file = None
+    last_file = None
 
     def __init__(self):
         self.api = Api()
@@ -22,7 +22,6 @@ class Player(xbmc.Player):
 
     def onPlayBackStarted(self):
         # Will be called when kodi starts playing a file
-        self.api.reset_addon_data()
         if utils.settings("developerMode") == "true":
             self.developer.developer_play_back()
 


### PR DESCRIPTION
Having the reset in OnPlayBackStarted causes the dialog to sometimes not show up, especially if up next information is sent as OnPlayBackStarted triggers. 

It will also correct the dialog showing up when transitioning to the next episode. It discards the saved data once we are done with it.