### PR TITLE
Fix play next race condition

### DIFF
--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -24,7 +24,7 @@ class Monitor(xbmc.Monitor):
             if self.waitForAbort(1):
                 # Abort was requested while waiting. We should exit
                 break
-            if self.player.isPlaying():
+            if self.player.is_tracking():
                 try:
                     play_time = self.player.getTime()
                     total_time = self.player.getTotalTime()
@@ -39,6 +39,7 @@ class Monitor(xbmc.Monitor):
                             self.log("Calling autoplayback totaltime - playtime is %s" % (total_time - play_time), 2)
                             self.playback_manager.launch_up_next()
                             self.log("Up Next style autoplay succeeded.", 2)
+                            self.player.disable_tracking()
 
                 except Exception as e:
                     self.log("Exception in Playback Monitor Service: %s" % repr(e))

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -8,6 +8,7 @@ from resources.lib.state import State
 # service class for playback monitoring
 class Player(xbmc.Player):
     last_file = None
+    track = False
 
     def __init__(self):
         self.api = Api()
@@ -20,13 +21,21 @@ class Player(xbmc.Player):
     def get_last_file(self):
         return self.last_file
 
+    def is_tracking(self):
+        return self.track
+
+    def disable_tracking(self):
+        self.track = False
+
     def onPlayBackStarted(self):
         # Will be called when kodi starts playing a file
+        self.track = True
         if utils.settings("developerMode") == "true":
             self.developer.developer_play_back()
 
     def onPlayBackStopped(self):
         # Will be called when user stops playing a file.
         self.last_file = None
+        self.disable_tracking()
         self.api.reset_addon_data()
         State() # reset state


### PR DESCRIPTION
If the play data is received before onPlayBackStated is called, the player state is then outdated with previous total time and play time, causing up next to trigger as play next starts.