### PR TITLE
Fix race condition on slower devices

### DIFF
--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -29,6 +29,7 @@ class Player(xbmc.Player):
 
     def onPlayBackStarted(self):
         # Will be called when kodi starts playing a file
+        xbmc.sleep(5000) # Delay for slower devices, should really use onAVStarted for Leia
         self.track = True
         if utils.settings("developerMode") == "true":
             self.developer.developer_play_back()


### PR DESCRIPTION
Delay start tracking by 5s to ensure player information has the chance to update on slower devices and prevent up next from showing right as playback starts.