### PR TITLE
Fix stop for Kodi playback

### DIFF
--- a/resources/lib/playbackManager.py
+++ b/resources/lib/playbackManager.py
@@ -44,7 +44,9 @@ class PlaybackManager:
             should_play_default, should_play_non_default = (
                 self.extract_play_info(next_up_page, showing_next_up_page, showing_still_watching_page,
                                        still_watching_page, total_time))
-
+            if not self.state.track:
+                self.log("exit launch_popup early due to disabled tracking", 2)
+                return
             play_item_option_1 = (should_play_default and self.state.playMode == "0")
             play_item_option_2 = (should_play_non_default and self.state.playMode == "1")
             if play_item_option_1 or play_item_option_2:

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -12,31 +12,30 @@ class Player(xbmc.Player):
 
     def __init__(self):
         self.api = Api()
+        self.state = State()
         self.developer = Developer()
         xbmc.Player.__init__(self)
 
     def set_last_file(self, file):
-        self.last_file = file
+        self.state.last_file = file
 
     def get_last_file(self):
-        return self.last_file
+        return self.state.last_file
 
     def is_tracking(self):
-        return self.track
+        return self.state.track
 
     def disable_tracking(self):
-        self.track = False
+        self.state.track = False
 
     def onPlayBackStarted(self):
         # Will be called when kodi starts playing a file
         xbmc.sleep(5000) # Delay for slower devices, should really use onAVStarted for Leia
-        self.track = True
+        self.state.track = True
         if utils.settings("developerMode") == "true":
             self.developer.developer_play_back()
 
     def onPlayBackStopped(self):
         # Will be called when user stops playing a file.
-        self.last_file = None
-        self.disable_tracking()
         self.api.reset_addon_data()
-        State() # reset state
+        self.state =State() # reset state

--- a/resources/lib/state.py
+++ b/resources/lib/state.py
@@ -16,4 +16,5 @@ class State:
         self.current_episode_id = None
         self.tv_show_id = None
         self.played_in_a_row = 1
-
+        self.last_file = None
+        self.track = False


### PR DESCRIPTION
Move tracking to State is to better control what happens between player events and playbackManager behavior. This will allow for user stop during the up next dialog to have an effect.