### PR TITLE
Add priority to existing playlist & endtime prop

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -28,6 +28,22 @@ class Api:
     def play_kodi_item(episode):
         utils.JSONRPC("Player.Open", id=0).execute({"item": {"episodeid": episode["episodeid"]}})
 
+    def get_next_in_playlist(self, position):
+        result = utils.JSONRPC("Playlist.GetItems").execute({
+            "playlistid": 1,
+            "limits": {"start": position+1, "end": position+2},
+            "properties": ["title", "playcount", "season", "episode", "showtitle", "plot",
+                           "file", "rating", "resume", "tvshowid", "art", "firstaired", "runtime", "writer",
+                           "dateadded", "lastplayed" , "streamdetails"]})
+        if result:
+            self.log("Got details of next playlist item %s" % json.dumps(result), 2)
+            if "result" in result and result["result"].get("items"):
+                item = result["result"]["items"][0]
+                if item["type"] == "episode":
+                    item["episodeid"] = item["id"]
+                    item["tvshowid"] = item.get("tvshowid", item["id"])
+                    return item
+
     def play_addon_item(self):
         self.log("sending data to addon to play:  %s " % json.dumps(self.data['play_info']), 2)
         utils.event(self.data['id'], self.data['play_info'], "upnextprovider")

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -26,9 +26,7 @@ class Api:
 
     @staticmethod
     def play_kodi_item(episode):
-        xbmc.executeJSONRPC(
-            '{ "jsonrpc": "2.0", "id": 0, "method": "Player.Open", '
-            '"params": { "item": {"episodeid": ' + str(episode["episodeid"]) + '} } }')
+        utils.JSONRPC("Player.Open", id=0).execute({"item": {"episodeid": episode["episodeid"]}})
 
     def play_addon_item(self):
         self.log("sending data to addon to play:  %s " % json.dumps(self.data['play_info']), 2)
@@ -53,40 +51,34 @@ class Api:
 
     def get_now_playing(self):
         # Get the active player
-        result = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "id": 1, "method": "Player.GetActivePlayers"}')
+        result = utils.JSONRPC("Player.GetActivePlayers").execute()
         self.log("Got active player %s" % json.dumps(result), 2)
-        result = json.loads(result)
 
         # Seems to work too fast loop whilst waiting for it to become active
         while not result["result"]:
-            result = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "id": 1, "method": "Player.GetActivePlayers"}')
+            result = utils.JSONRPC("Player.GetActivePlayers").execute()
             self.log("Got active player %s" % json.dumps(result), 2)
-            result = json.loads(result)
 
         if 'result' in result and result["result"][0] is not None:
             playerid = result["result"][0]["playerid"]
 
             # Get details of the playing media
             self.log("Getting details of now playing media", 2)
-            result = xbmc.executeJSONRPC(
-                '{"jsonrpc": "2.0", "id": 1, "method": "Player.GetItem", "params": {"playerid": %s, '
-                '"properties": ["showtitle", "tvshowid", "episode", "season", "playcount","genre","plotoutline"] } }'
-                % str(playerid))
+            result = utils.JSONRPC("Player.GetItem").execute({
+                "playerid": playerid, 
+                "properties": ["showtitle","tvshowid","episode","season","playcount","genre","plotoutline"]})
             self.log("Got details of now playing media %s" % json.dumps(result), 2)
-
-            result = json.loads(result)
             return result
 
     def handle_kodi_lookup_of_episode(self, tvshowid, current_file, include_watched, current_episode_id):
-        result = xbmc.executeJSONRPC(
-            '{"jsonrpc": "2.0", "method": "VideoLibrary.GetEpisodes", "params": {"tvshowid": %d, '
-            '"properties": [ "title", "playcount", "season", "episode", "showtitle", "plot", '
-            '"file", "rating", "resume", "tvshowid", "art", "firstaired", "runtime", "writer", '
-            '"dateadded", "lastplayed" , "streamdetails"], "sort": {"method": "episode"}}, "id": 1}'
-            % tvshowid)
+        result = utils.JSONRPC("VideoLibrary.GetEpisodes").execute({
+            "tvshowid": tvshowid, 
+            "properties": ["title", "playcount", "season", "episode", "showtitle", "plot",
+                           "file", "rating", "resume", "tvshowid", "art", "firstaired", "runtime", "writer",
+                           "dateadded", "lastplayed" , "streamdetails"],
+            "sort": {"method": "episode"}})
 
         if result:
-            result = json.loads(result)
             self.log("Got details of next up episode %s" % json.dumps(result), 2)
             xbmc.sleep(100)
 
@@ -96,16 +88,15 @@ class Api:
                 return episode
 
     def handle_kodi_lookup_of_current_episode(self, tvshowid, current_episode_id):
-        result = xbmc.executeJSONRPC(
-            '{"jsonrpc": "2.0", "method": "VideoLibrary.GetEpisodes", "params": {"tvshowid": %d, '
-            '"properties": [ "title", "playcount", "season", "episode", "showtitle", "plot", '
-            '"file", "rating", "resume", "tvshowid", "art", "firstaired", "runtime", "writer", '
-            '"dateadded", "lastplayed" , "streamdetails"], "sort": {"method": "episode"}}, "id": 1}'
-            % tvshowid)
+        result = utils.JSONRPC("VideoLibrary.GetEpisodes").execute({
+            "tvshowid": tvshowid,
+            "properties": ["title", "playcount", "season", "episode", "showtitle", "plot",
+                           "file", "rating", "resume", "tvshowid", "art", "firstaired", "runtime", "writer",
+                           "dateadded", "lastplayed" , "streamdetails"],
+            "sort": {"method": "episode"}})
         self.log("Find current episode called", 2)
         position = 0
         if result:
-            result = json.loads(result)
             xbmc.sleep(100)
 
             # Find the next unwatched and the newest added episodes
@@ -129,16 +120,8 @@ class Api:
                 return episode
 
     def showtitle_to_id(self, title):
-        query = {
-            "jsonrpc": "2.0",
-            "method": "VideoLibrary.GetTVShows",
-            "params": {
-                "properties": ["title"]
-            },
-            "id": "libTvShows"
-        }
         try:
-            json_result = json.loads(xbmc.executeJSONRPC(json.dumps(query, encoding='utf-8')))
+            json_result = utils.JSONRPC("VideoLibrary.GetTVShows", id="libTvShows").execute({"properties": ["title"]})
             if 'result' in json_result and 'tvshows' in json_result['result']:
                 json_result = json_result['result']['tvshows']
                 for tvshow in json_result:
@@ -154,16 +137,11 @@ class Api:
         show_episode = int(show_episode)
         episodeid = 0
         query = {
-            "jsonrpc": "2.0",
-            "method": "VideoLibrary.GetEpisodes",
-            "params": {
-                "properties": ["season", "episode"],
-                "tvshowid": int(showid)
-            },
-            "id": "1"
+            "properties": ["season", "episode"],
+            "tvshowid": int(showid)
         }
         try:
-            json_result = json.loads(xbmc.executeJSONRPC(json.dumps(query, encoding='utf-8')))
+            json_result = utils.JSONRPC("VideoLibrary.GetEpisodes").execute(query)
             if 'result' in json_result and 'episodes' in json_result['result']:
                 json_result = json_result['result']['episodes']
                 for episode in json_result:

--- a/resources/lib/playItem.py
+++ b/resources/lib/playItem.py
@@ -1,3 +1,4 @@
+import xbmc
 import json
 import resources.lib.utils as utils
 from resources.lib.api import Api
@@ -36,6 +37,13 @@ class PlayItem:
                 self.state.current_tv_show_id = current_episode["tvshowid"]
                 self.state.played_in_a_row = 1
         return episode
+
+    def get_next(self):
+        playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
+        position = playlist.getposition()
+        if position < playlist.size():
+            return self.api.get_next_in_playlist(position)
+        return False
 
     def handle_now_playing_result(self, result):
         if 'result' in result:

--- a/resources/lib/stillwatching.py
+++ b/resources/lib/stillwatching.py
@@ -79,13 +79,16 @@ class StillWatching(xbmcgui.WindowXMLDialog):
     def setProgressStepSize(self, progressStepSize):
         self.progressStepSize = progressStepSize
 
-    def updateProgressControl(self):
+    def updateProgressControl(self, endtime):
         # noinspection PyBroadException
         try:
             self.currentProgressPercent = self.currentProgressPercent - self.progressStepSize
             self.progressControl = self.getControl(3014)
             if self.progressControl is not None:
                 self.progressControl.setPercent(self.currentProgressPercent)
+            if endtime:
+                self.setProperty(
+                    'endtime', str(endtime))
         except Exception:
             pass
 

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -78,13 +78,16 @@ class UpNext(xbmcgui.WindowXMLDialog):
     def setProgressStepSize(self, progressStepSize):
         self.progressStepSize = progressStepSize
 
-    def updateProgressControl(self):
+    def updateProgressControl(self, endtime):
         # noinspection PyBroadException
         try:
             self.currentProgressPercent = self.currentProgressPercent - self.progressStepSize
             self.progressControl = self.getControl(3014)
             if self.progressControl is not None:
                 self.progressControl.setPercent(self.currentProgressPercent)
+            if endtime:
+                self.setProperty(
+                    'endtime', str(endtime))
         except Exception:
             pass
 

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -160,3 +160,26 @@ def unicode_to_ascii(text):
 def calculate_progress_steps(period):
     return (100.0 / int(period)) / 10
 
+class JSONRPC(object):
+    id = 1
+    jsonrpc = "2.0"
+
+    def __init__(self, method, **kwargs):
+        self.method = method
+        for arg in kwargs:
+            self.arg = kwargs[arg]
+
+    def _query(self):
+        query = {
+            'jsonrpc': self.jsonrpc,
+            'id': self.id,
+            'method': self.method,
+        }
+        if self.params is not None:
+            query['params'] = self.params
+        return json.dumps(query)
+
+    def execute(self, params=None):
+        self.params = params
+        return json.loads(xbmc.executeJSONRPC(self._query()))
+

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,7 +6,7 @@
         <setting id="autoPlayMode" type="enum" label="30005" lvalues="30040|30041" default="0"/>
         <setting id="playedInARow" type="number" label="30009" default="3" visible="true" enable="true"/>
         <setting id="includeWatched" type="bool" label="30013" default="false" visible="true" enable="true"/>
-        <setting id="enablePlaylist" type="bool" label="30032" default="false" visible="true" enable="true"/>
+        <setting id="enablePlaylist" type="bool" visible="false" enable="false"/><!--to avoid log spam just disable setting-->
     </category>
     <category label="30004">
         <setting id="disableNextUp" type="bool" label="30014" default="false" visible="true" enable="true"/>


### PR DESCRIPTION
This is to resolve conflict between shuffled playlist and up next. If episodes are already queued up and we are not at the end of the playlist, grab the next episode to play from the existing playlist.

It also adds the endtime as a dialog property to reflect the endtime of the next episode when the dialog is displayed.

"runtime" could be added as an optional field to next_info data, to fill endtime value. The runtime should be in seconds.