### PR TITLE
Fix prepended spaces in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Up Next
 
-This addon shows a popup window notification automatically to prompt for playing the next unwatched episode. 
+This addon shows a popup window notification automatically to prompt for playing the next unwatched episode.
 
 The default settings should be enough for most, but changes can be made in the addon settings (*the addon is in the services section of kodi addons*)
 
@@ -9,6 +9,6 @@ The default settings should be enough for most, but changes can be made in the a
   * simple/fancy mode - by default the windows are in fancy mode, but a simpler version can be selected to be shown in the settings.
   * The notification time can be adjusted (default 30 seconds before the end)
   * The default action (ie Play/Do not Play) when nothing is pressed can also be configured
-  * The number of episodes played in a row with no intervention to bring up the still watching window can be adjusted.                                      
+  * The number of episodes played in a row with no intervention to bring up the still watching window can be adjusted.
 
 For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Integration) and [Skinners](https://github.com/im85288/service.upnext/wiki/Skinners) see the [wiki](https://github.com/im85288/service.upnext/wiki)     

--- a/addon.xml
+++ b/addon.xml
@@ -6,12 +6,9 @@
     </requires>
     <extension library="service.py" point="xbmc.service"/>
     <extension point="xbmc.addon.metadata">
-        <summary lang="en_GB">Provides a netflix style pop up notification for watching the next episode with fancy/simple
-            modes.
+        <summary lang="en_GB">Provides a netflix style pop up notification for watching the next episode with fancy/simple modes.
         </summary>
-        <description lang="en_GB">Provides a netflix style pop up notification for watching the next episode with
-            fancy/simple modes. A prompt to check if your still watching also occurs after a few automatically watched
-            shows in a row.
+        <description lang="en_GB">Provides a netflix style pop up notification for watching the next episode with fancy/simple modes. A prompt to check if your still watching also occurs after a few automatically watched shows in a row.
         </description>
         <platform>all</platform>
         <assets>


### PR DESCRIPTION
The addon.xml includes indented lines in a single paragraph.
Unfortunately this causes newlines and added whitespace in the Kodi
add-on interface.

This PR fixes that.

This PR also removes trailing spaces in README.md.