### PR TITLE
This adds sanity checks for Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
-
+# Test caches
+*.pyc
 *.pyo
+.tox/
+
+# Logs
+kodi-addon-checker-report.log
+kodi-addon-checker.log

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,10 @@
+[MESSAGES CONTROL]
+disable=
+    duplicate-code,
+    import-outside-toplevel,
+    line-too-long,
+    missing-docstring,
+    old-style-class,
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-instance-attributes,

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+ENVS := flake8,py27,py36
+export PYTHONPATH := $(CURDIR)/resources/lib
+addon_xml := addon.xml
+
+# Collect information to build as sensible package name
+name = $(shell xmllint --xpath 'string(/addon/@id)' $(addon_xml))
+version = $(shell xmllint --xpath 'string(/addon/@version)' $(addon_xml))
+git_branch = $(shell git rev-parse --abbrev-ref HEAD)
+git_hash = $(shell git rev-parse --short HEAD)
+
+zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
+include_files = addon.xml LICENSE README.md resources/
+include_paths = $(patsubst %,$(name)/%,$(include_files))
+exclude_files = \*.new \*.orig \*.pyc \*.pyo
+zip_dir = $(name)/
+
+blue = \e[1;34m
+white = \e[1;37m
+reset = \e[0;39m
+
+.PHONY: test
+
+all: test zip
+
+package: zip
+
+test: sanity
+
+sanity: tox pylint language
+
+tox:
+	@echo -e "$(white)=$(blue) Starting sanity tox test$(reset)"
+	tox -q -e $(ENVS)
+
+pylint:
+	@echo -e "$(white)=$(blue) Starting sanity pylint test$(reset)"
+	pylint resources/lib/ test/
+
+language:
+	@echo -e "$(white)=$(blue) Checking translations$(reset)"
+	msgcmp resources/language/resource.language.nl_nl/strings.po resources/language/resource.language.en_gb/strings.po
+
+addon: clean
+	@echo -e "$(white)=$(blue) Starting sanity addon tests$(reset)"
+	kodi-addon-checker . --branch=krypton
+	kodi-addon-checker . --branch=leia
+
+zip: clean
+	@echo -e "$(white)=$(blue) Building new package$(reset)"
+	@rm -f ../$(zip_name)
+	cd ..; zip -r $(zip_name) $(include_paths) -x $(exclude_files)
+	@echo -e "$(white)=$(blue) Successfully wrote package as: $(white)../$(zip_name)$(reset)"
+
+clean:
+	find . -name '*.pyc' -type f -delete
+	find . -name '*.pyo' -type f -delete
+	find . -name '__pycache__' -type d -delete
+	rm -rf .pytest_cache/ .tox/
+	rm -f *.log

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = py27,py36,py37,flake8
+skipsdist = True
+
+[testenv:flake8]
+commands =
+    - {envbindir}/flake8
+deps =
+    flake8
+    flake8-coding
+    flake8-future-import
+
+[flake8]
+builtins = func
+max-line-length = 160
+ignore = E129,FI13,FI50,FI51,FI53,FI54,W503
+require-code = True
+min-version = 2.7
+
+[pytest]
+filterwarnings = default
+
+[pycodestyle]
+max-line-length = 160
+


### PR DESCRIPTION
This adds sanity checks for Python, but doesn't include any fixes just
yet. Once we have everything fixed to a certain standard, we can enable
this in Travis for new contributions.

This also add a `make zip` target for creating test builds.