### PR TITLE
Simplify summary/description and settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv2-yellow.svg)](https://opensource.org/licenses/GPL-2.0)
 [![Contributors](https://img.shields.io/github/contributors/im85288/service.upnext.svg)](https://github.com/im85288/service.upnext/graphs/contributors)
 
-# Up Next
+# Up Next - Proposes to play the next episode automatically
 
-This addon shows a popup window notification automatically to prompt for playing the next unwatched episode.
+This Kodi add-on shows a Netflix-style notification for watching the next episode. After a few automatic iterations it asks the user if he is still there watching.
 
-The default settings should be enough for most, but changes can be made in the addon settings (*the addon is in the services section of kodi addons*)
+A lot of existing add-ons already integrate with this service out-of-the-box.
 
-##### Addon Settings:
+## Settings
+The add-on has various settings to fine-tune the experience, however the default settings should be fine for most.
 
-  * simple/fancy mode - by default the windows are in fancy mode, but a simpler version can be selected to be shown in the settings.
-  * The notification time can be adjusted (default 30 seconds before the end)
-  * The default action (ie Play/Do not Play) when nothing is pressed can also be configured
-  * The number of episodes played in a row with no intervention to bring up the still watching window can be adjusted.
+  * Simple or fancy mode (defaults to fancy mode, but a more simple interface is possible)
+  * The notification time can be adjusted (defaults to 30 seconds before the end)
+  * The default action can be confnigured, i.e. should it advance to the next episode (default) when the user does not respond, or stop
+  * The number of episodes to play automatically before asking the user if he is still there (defaults to 3 episodes)
+
+> NOTE: The add-on settings are found in the Kodi add-ons section, in the *Services* category.
 
 For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Integration) and [Skinners](https://github.com/im85288/service.upnext/wiki/Skinners) see the [wiki](https://github.com/im85288/service.upnext/wiki)

--- a/addon.xml
+++ b/addon.xml
@@ -5,10 +5,10 @@
     </requires>
     <extension library="service.py" point="xbmc.service"/>
     <extension point="xbmc.addon.metadata">
-        <summary lang="en_GB">Provides a netflix style pop up notification for watching the next episode with fancy/simple modes.
-        </summary>
-        <description lang="en_GB">Provides a netflix style pop up notification for watching the next episode with fancy/simple modes. A prompt to check if your still watching also occurs after a few automatically watched shows in a row.
-        </description>
+        <summary lang="en_GB">Propose to play the next episode automatically</summary>
+        <description lang="en_GB">A service add-on that shows a Netflix-style notification for watching the next episode. After a few automatic iterations it asks the user if he is still there watching.
+
+A lot of existing add-ons already integrate with this service out-of-the-box.</description>
         <platform>all</platform>
         <assets>
             <icon>icon.png</icon>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,20 +4,20 @@
         <setting id="simpleMode" type="enum" label="30025" lvalues="30038|30039" default="1"/>
         <setting id="autoPlaySeasonTime" type="slider" label="30001" default="30" range="10,5,180" option="int" />
         <setting id="autoPlayMode" type="enum" label="30005" lvalues="30040|30041" default="0"/>
-        <setting id="playedInARow" type="number" label="30009" default="3" visible="true" enable="true"/>
-        <setting id="includeWatched" type="bool" label="30013" default="false" visible="true" enable="true"/>
+        <setting id="playedInARow" type="number" label="30009" default="3"/>
+        <setting id="includeWatched" type="bool" label="30013" default="false"/>
         <setting id="enablePlaylist" type="bool" visible="false" enable="false"/><!--to avoid log spam just disable setting-->
-        <setting id="stopAfterClose" type="bool" label="30050" default="false" visible="true" enable="true"/>
+        <setting id="stopAfterClose" type="bool" label="30050" default="false"/>
     </category>
     <category label="30004">
-        <setting id="disableNextUp" type="bool" label="30014" default="false" visible="true" enable="true"/>
+        <setting id="disableNextUp" type="bool" label="30014" default="false"/>
         <setting id="logLevel" type="enum" label="30002" lvalues="30042|30043|30044" default="0"/>
-        <setting id="shortPlayMode" type="bool" label="30017" default="false" visible="true" enable="true"/>
-        <setting id="shortPlayLength" type="number" label="30018" default="10" visible="true" enable="true"/>
-        <setting id="shortPlayNotification" type="bool" label="30019" default="true" visible="true" enable="true"/>
+        <setting id="shortPlayMode" type="bool" label="30017" default="false"/>
+        <setting id="shortPlayLength" type="number" label="30018" default="10"/>
+        <setting id="shortPlayNotification" type="bool" label="30019" default="true"/>
     </category>
     <category label="30028">
-        <setting id="developerMode" type="bool" label="30029" default="false" visible="true" enable="true"/>
+        <setting id="developerMode" type="bool" label="30029" default="false"/>
         <setting id="windowMode" type="enum" label="30030" lvalues="30045|30046|30047|30048" visible="eq(-1,true)" default="0"/>
     </category>
 </settings>


### PR DESCRIPTION
I noticed both the summary and description where showing the same
information. Now the summary is a lot shorter, and the details are in
the description.

For the settings, I removed the default enable/visible defaults.