### PR TITLE
Fix playlist logic

### DIFF
--- a/resources/lib/playitem.py
+++ b/resources/lib/playitem.py
@@ -45,7 +45,8 @@ class PlayItem:
     def get_next(self):
         playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
         position = playlist.getposition()
-        if position < playlist.size():
+        # A playlist with only one element has no next item and xbmc.PlayList().getposition() starts counting from zero
+        if playlist.size() > 1 and position < (playlist.size() - 1):
             return self.api.get_next_in_playlist(position)
         return False
 


### PR DESCRIPTION
In https://github.com/im85288/service.upnext/commit/e23945afa5f9e8640659af72c33f454b80bd442f existing playlist items got priority over "normal" episodes. But the logic of this implementation was just plain wrong!

This completely broke the Up Next feature when playing multiple episodes with video add-ons like Netflix. Luckily, this commit was never part of the 1.0.1 version available in the official Kodi repo, so the impact was limited.

This pull request fixes the logic taking into account the following facts:
- A playlist with only one item doesn't have a next item
- xbmc.PlayList().getposition() starts counting from zero