### PR TITLE
Support Back button action

### DIFF
--- a/resources/lib/stillwatching.py
+++ b/resources/lib/stillwatching.py
@@ -7,6 +7,7 @@ import xbmcgui
 from .statichelper import from_unicode
 
 ACTION_PLAYER_STOP = 13
+ACTION_NAV_BACK = 92
 OS_MACHINE = machine()
 
 
@@ -105,4 +106,7 @@ class StillWatching(xbmcgui.WindowXMLDialog):
 
     def onAction(self, action):  # pylint: disable=invalid-name
         if action == ACTION_PLAYER_STOP:
+            self.close()
+        elif action == ACTION_NAV_BACK:
+            self.set_cancel(True)
             self.close()

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -9,6 +9,7 @@ from . import utils
 from .statichelper import from_unicode
 
 ACTION_PLAYER_STOP = 13
+ACTION_NAV_BACK = 92
 OS_MACHINE = machine()
 
 
@@ -108,4 +109,7 @@ class UpNext(xbmcgui.WindowXMLDialog):
 
     def onAction(self, action):  # pylint: disable=invalid-name
         if action == ACTION_PLAYER_STOP:
+            self.close()
+        elif action == ACTION_NAV_BACK:
+            self.set_cancel(True)
             self.close()


### PR DESCRIPTION
The user should be able to use the back button to dismiss Up Next.
This behaves as if nothing had happened, except that it is clear that
the user is still watching. It also results in Up Next not playing the
next episode.

This fixes #73 