### PR TITLE
Fix non-string/unicode property values

### DIFF
--- a/resources/lib/statichelper.py
+++ b/resources/lib/statichelper.py
@@ -5,14 +5,16 @@
 from __future__ import absolute_import, division, unicode_literals
 
 
-def to_unicode(text, encoding='utf-8'):
+def to_unicode(text, encoding='utf-8', errors='strict'):
     ''' Force text to unicode '''
-    return text.decode(encoding) if isinstance(text, bytes) else text
+    if isinstance(text, bytes):
+        return text.decode(encoding, errors)
+    return text
 
 
-def from_unicode(text, encoding='utf-8'):
+def from_unicode(text, encoding='utf-8', errors='strict'):
     ''' Force unicode to text '''
     import sys
     if sys.version_info.major == 2 and isinstance(text, unicode):  # noqa: F821; pylint: disable=undefined-variable
-        return text.encode(encoding)
+        return text.encode(encoding, errors)
     return text

--- a/resources/lib/stillwatching.py
+++ b/resources/lib/stillwatching.py
@@ -33,28 +33,28 @@ class StillWatching(xbmcgui.WindowXMLDialog):
 
     def set_info(self):
         episode_info = '%(season)sx%(episode)s.' % self.item
-        if self.item.get('rating') is not None:
-            rating = round(float(self.item.get('rating')), 1)
+        if self.item.get('rating') is None:
+            rating = ''
         else:
-            rating = None
+            rating = str(round(float(self.item.get('rating')), 1))
 
         if self.item is not None:
             art = self.item.get('art')
-            self.setProperty('fanart', from_unicode(art.get('tvshow.fanart', '')))
-            self.setProperty('landscape', from_unicode(art.get('tvshow.landscape', '')))
-            self.setProperty('clearart', from_unicode(art.get('tvshow.clearart', '')))
-            self.setProperty('clearlogo', from_unicode(art.get('tvshow.clearlogo', '')))
-            self.setProperty('poster', from_unicode(art.get('tvshow.poster', '')))
-            self.setProperty('thumb', from_unicode(art.get('thumb', '')))
-            self.setProperty('plot', from_unicode(self.item.get('plot', '')))
-            self.setProperty('tvshowtitle', from_unicode(self.item.get('showtitle', '')))
-            self.setProperty('title', from_unicode(self.item.get('title', '')))
-            self.setProperty('season', from_unicode(str(self.item.get('season', ''))))
-            self.setProperty('episode', from_unicode(str(self.item.get('episode', ''))))
-            self.setProperty('seasonepisode', from_unicode(episode_info))
-            self.setProperty('year', from_unicode(str(self.item.get('firstaired', ''))))
-            self.setProperty('rating', from_unicode(rating))
-            self.setProperty('playcount', from_unicode(self.item.get('playcount', '')))
+            self.setProperty('fanart', art.get('tvshow.fanart', ''))
+            self.setProperty('landscape', art.get('tvshow.landscape', ''))
+            self.setProperty('clearart', art.get('tvshow.clearart', ''))
+            self.setProperty('clearlogo', art.get('tvshow.clearlogo', ''))
+            self.setProperty('poster', art.get('tvshow.poster', ''))
+            self.setProperty('thumb', art.get('thumb', ''))
+            self.setProperty('plot', self.item.get('plot', ''))
+            self.setProperty('tvshowtitle', self.item.get('showtitle', ''))
+            self.setProperty('title', self.item.get('title', ''))
+            self.setProperty('season', str(self.item.get('season', '')))
+            self.setProperty('episode', str(self.item.get('episode', '')))
+            self.setProperty('seasonepisode', episode_info)
+            self.setProperty('year', str(self.item.get('firstaired', '')))
+            self.setProperty('rating', rating)
+            self.setProperty('playcount', str(self.item.get('playcount', 0)))
 
     def prepare_progress_control(self):
         self.progress_control = self.getControl(3014)

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -39,28 +39,28 @@ class UpNext(xbmcgui.WindowXMLDialog):
 
     def set_info(self):
         episode_info = '%(season)sx%(episode)s.' % self.item
-        if self.item.get('rating') is not None:
-            rating = round(float(self.item.get('rating')), 1)
+        if self.item.get('rating') is None:
+            rating = ''
         else:
-            rating = None
+            rating = str(round(float(self.item.get('rating')), 1))
 
         if self.item is not None:
             art = self.item.get('art')
-            self.setProperty('fanart', from_unicode(art.get('tvshow.fanart', '')))
-            self.setProperty('landscape', from_unicode(art.get('tvshow.landscape', '')))
-            self.setProperty('clearart', from_unicode(art.get('tvshow.clearart', '')))
-            self.setProperty('clearlogo', from_unicode(art.get('tvshow.clearlogo', '')))
-            self.setProperty('poster', from_unicode(art.get('tvshow.poster', '')))
-            self.setProperty('thumb', from_unicode(art.get('thumb', '')))
-            self.setProperty('plot', from_unicode(self.item.get('plot', '')))
-            self.setProperty('tvshowtitle', from_unicode(self.item.get('showtitle', '')))
-            self.setProperty('title', from_unicode(self.item.get('title', '')))
-            self.setProperty('season', from_unicode(str(self.item.get('season', ''))))
-            self.setProperty('episode', from_unicode(str(self.item.get('episode', ''))))
-            self.setProperty('seasonepisode', from_unicode(episode_info))
-            self.setProperty('year', from_unicode(str(self.item.get('firstaired', ''))))
-            self.setProperty('rating', from_unicode(rating))
-            self.setProperty('playcount', from_unicode(self.item.get('playcount', '')))
+            self.setProperty('fanart', art.get('tvshow.fanart', ''))
+            self.setProperty('landscape', art.get('tvshow.landscape', ''))
+            self.setProperty('clearart', art.get('tvshow.clearart', ''))
+            self.setProperty('clearlogo', art.get('tvshow.clearlogo', ''))
+            self.setProperty('poster', art.get('tvshow.poster', ''))
+            self.setProperty('thumb', art.get('thumb', ''))
+            self.setProperty('plot', self.item.get('plot', ''))
+            self.setProperty('tvshowtitle', self.item.get('showtitle', ''))
+            self.setProperty('title', self.item.get('title', ''))
+            self.setProperty('season', str(self.item.get('season', '')))
+            self.setProperty('episode', str(self.item.get('episode', '')))
+            self.setProperty('seasonepisode', episode_info)
+            self.setProperty('year', str(self.item.get('firstaired', '')))
+            self.setProperty('rating', rating)
+            self.setProperty('playcount', str(self.item.get('playcount', 0)))
 
     def prepare_progress_control(self):
         self.progress_control = self.getControl(3014)


### PR DESCRIPTION
This PR includes:
- Improvements to from_unicode/to_unicode (unused)
- Fix rating/playcount type to string
- Don't use from_unicode for setProperty as it accepts str and unicode
  (on PY2 and PY3)

This fixes #83 