### PR TITLE
Always reset state when playback finishes

### DIFF
--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -51,3 +51,13 @@ class Player(xbmc.Player):
         ''' Will be called when user stops playing a file '''
         self.api.reset_addon_data()
         self.state = State()  # Reset state
+
+    def onPlayBackEnded(self):  # pylint: disable=invalid-name
+        ''' Will be called when Kodi has ended playing a file '''
+        self.api.reset_addon_data()
+        self.state = State()  # Reset state
+
+    def onPlayBackError(self):  # pylint: disable=invalid-name
+        ''' Will be called when when playback stops due to an error '''
+        self.api.reset_addon_data()
+        self.state = State()  # Reset state


### PR DESCRIPTION
This fixes a bug where you get an "Up Next" notification screen to watch a **previous** episode when you play the very last episode of a series.

Steps to reproduce this bug with the Netflix add-on:
- play an episode that has a next episode
- seek beyond the end time of the episode, so you never see the "Up Next" notification and you trigger `onPlayBackEnded`
- play the very last episode of a series, so there exists no next episode
- wait until the very last episode shows the "Up Next" notification screen a previous episode

Please test if this effectively fixes this bug before merging.
