### PR TITLE
convert bytes to str before using json.loads for python < 3.6 compat

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -78,7 +78,11 @@ def decode_data(data):
     ''' Decode data coming from a notification event '''
     data = json.loads(data)
     if data:
-        return to_unicode(json.loads(unhexlify(data[0])))
+        json_data = unhexlify(data[0])
+        # NOTE: With Python 3.5 and older json.loads does not support bytes or bytearray
+        if isinstance(json_data, bytes):
+            json_data = json_data.decode('utf-8')
+        return to_unicode(json.loads(json_data))
     return None
 
 


### PR DESCRIPTION
Found this on my device with OSMC installed,  looks like OSMC is using Python 3.5 (at least currently)

- fixes utils.decode_data for `Python 3.0 -> 3.5`
- json.loads didn't support bytes or bytearray until Python 3.6