### PR TITLE
Add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
 - '2.7'
+- '3.5'
 - '3.6'
 - '3.7'
 - '3.8'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-ENVS := flake8,py27,py36
 export PYTHONPATH := $(CURDIR):test/
 addon_xml := addon.xml
 
@@ -32,7 +31,7 @@ sanity: tox pylint language
 
 tox:
 	@echo -e "$(white)=$(blue) Starting sanity tox test$(reset)"
-	tox -q -e $(ENVS)
+	tox -q
 
 pylint:
 	@echo -e "$(white)=$(blue) Starting sanity pylint test$(reset)"

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -63,6 +63,23 @@ def settings(setting, value=None):
     return None
 
 
+def decode_data(data):
+    ''' Decode data coming from a notification event '''
+    data = json.loads(data)
+    if not data:
+        return None
+    json_data = unhexlify(data[0])
+    # NOTE: With Python 3.5 and older json.loads does not support bytes or bytearray
+    if isinstance(json_data, bytes):
+        json_data = json_data.decode('utf-8')
+    return to_unicode(json.loads(json_data))
+
+
+def encode_data(data):
+    ''' Encode data for a notification event '''
+    return json.dumps([to_unicode(hexlify(json.dumps(data).encode()))])
+
+
 def event(message, data=None, sender=None):
     ''' Send internal notification event '''
     data = data or {}
@@ -70,20 +87,8 @@ def event(message, data=None, sender=None):
     jsonrpc(method='JSONRPC.NotifyAll', params=dict(
         sender='%s.SIGNAL' % sender,
         message=message,
-        data=[to_unicode(hexlify(json.dumps(data).encode()))],
+        data=encode_data(data),
     ))
-
-
-def decode_data(data):
-    ''' Decode data coming from a notification event '''
-    data = json.loads(data)
-    if data:
-        json_data = unhexlify(data[0])
-        # NOTE: With Python 3.5 and older json.loads does not support bytes or bytearray
-        if isinstance(json_data, bytes):
-            json_data = json_data.decode('utf-8')
-        return to_unicode(json.loads(json_data))
-    return None
 
 
 def log(msg, name=None, level=1):

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
+from resources.lib import utils
 
 xbmc = __import__('xbmc')
 xbmcaddon = __import__('xbmcaddon')
@@ -13,8 +14,14 @@ xbmcgui = __import__('xbmcgui')
 xbmcvfs = __import__('xbmcvfs')
 
 
-class TestUnicode(unittest.TestCase):
+class TestEncoding(unittest.TestCase):
 
     # This is a placeholder
-    def test_unicode(self):
-        self.assertEqual(True, True)
+    def test_encoding(self):
+        data = 'Foobar'
+
+        encoded_data = utils.encode_data(data)
+        print('hex encoded data: %r' % encoded_data)
+        decoded_data = utils.decode_data(encoded_data)
+        print('hex decoded data: %r' % decoded_data)
+        self.assertEqual(data, decoded_data)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-envlist = py27,py36,py37,flake8
+envlist = py27,py35,py36,py37,py38,flake8
 skipsdist = True
+skip_missing_interpreters = True
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
This adds unit tests for the encode/decoding routine to be tested on all supported Python versions.

These tests are added before merging #93 to have a baseline.