### PR TITLE
Fix issue with 24hour format detection

### DIFF
--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -10,7 +10,6 @@ from .api import Api
 from .player import Player
 from .playitem import PlayItem
 from .state import State
-from .utils import get_global_setting
 
 
 class PlaybackManager:  # pylint: disable=invalid-name
@@ -22,7 +21,6 @@ class PlaybackManager:  # pylint: disable=invalid-name
         self.play_item = PlayItem()
         self.state = State()
         self.player = Player()
-        self.clock_twelve = None
 
     def log(self, msg, level=2):
         utils.log(msg, name=self.__class__.__name__, level=level)
@@ -38,7 +36,6 @@ class PlaybackManager:  # pylint: disable=invalid-name
                 self.log('Error: no episode could be found to play next...exiting', 1)
                 return
         self.log('episode details %s' % episode, 2)
-        self.clock_twelve = bool(not get_global_setting('locale.use24hourclock'))
         self.launch_popup(episode, playlist_item)
         self.api.reset_addon_data()
 
@@ -109,7 +106,8 @@ class PlaybackManager:  # pylint: disable=invalid-name
             if episode_runtime:
                 end_time = total_time - play_time + episode.get('runtime')
                 end_time = datetime.now() + timedelta(seconds=end_time)
-                end_time = end_time.strftime('%I:%M %p' if self.clock_twelve else '%H:%M').lstrip('0')  # Remove leading zero on all platforms
+                time_format = xbmc.getRegion('time').replace(':%S', '')  # Strip off seconds
+                end_time = end_time.strftime(time_format).lstrip('0')  # Remove leading zero on all platforms
             else:
                 end_time = None
             if not self.state.pause:

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -10,6 +10,7 @@ from .api import Api
 from .player import Player
 from .playitem import PlayItem
 from .state import State
+from .statichelper import to_unicode
 
 
 class PlaybackManager:  # pylint: disable=invalid-name
@@ -37,7 +38,7 @@ class PlaybackManager:  # pylint: disable=invalid-name
                 self.log('Error: no episode could be found to play next...exiting', 1)
                 return
         self.log('episode details %s' % episode, 2)
-        self.clock_twelve = 'm' in xbmc.getInfoLabel('System.Time').lower()
+        self.clock_twelve = 'm' in to_unicode(xbmc.getInfoLabel('System.Time')).lower()
         self.launch_popup(episode, playlist_item)
         self.api.reset_addon_data()
 

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -10,7 +10,7 @@ from .api import Api
 from .player import Player
 from .playitem import PlayItem
 from .state import State
-from .statichelper import to_unicode
+from .utils import get_global_setting
 
 
 class PlaybackManager:  # pylint: disable=invalid-name
@@ -38,7 +38,7 @@ class PlaybackManager:  # pylint: disable=invalid-name
                 self.log('Error: no episode could be found to play next...exiting', 1)
                 return
         self.log('episode details %s' % episode, 2)
-        self.clock_twelve = 'm' in to_unicode(xbmc.getInfoLabel('System.Time')).lower()
+        self.clock_twelve = bool(not get_global_setting('locale.use24hourclock'))
         self.launch_popup(episode, playlist_item)
         self.api.reset_addon_data()
 


### PR DESCRIPTION
This is just a workaround because I don't think the implementation is
the best way to see if the clock is using a 24h format or not.

This fixes #106 