### PR TITLE
Use formatted sentences in translations

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -108,16 +108,16 @@ msgid "Close"
 msgstr "Schließen"
 
 msgctxt "#30035"
-msgid "seconds"
-msgstr "Sekunden"
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Wiedergabe fortsetzen in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] Sekunden"
 
 msgctxt "#30036"
-msgid "in"
-msgstr "in"
+msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Als Nächstes in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] Sekunden"
 
 msgctxt "#30037"
-msgid "Next Episode in"
-msgstr "Nächste Episode in"
+msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Nächste Episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] Sekunden"
 
 msgctxt "#30038"
 msgid "Simple"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -105,15 +105,15 @@ msgctxt "#30034"
 msgid "Close"
 msgstr ""
 
-msgctxt "#30035"  #30010 #30036 [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] #30035
+msgctxt "#30035"
 msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
 msgstr ""
 
-msgctxt "#30036"  #30008 #30036 [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] #30035
+msgctxt "#30036"
 msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
 msgstr ""
 
-msgctxt "#30037"  #30037 [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] #30035
+msgctxt "#30037"
 msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
 msgstr ""
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -105,16 +105,16 @@ msgctxt "#30034"
 msgid "Close"
 msgstr ""
 
-msgctxt "#30035"
-msgid "seconds"
+msgctxt "#30035"  #30010 #30036 [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] #30035
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
 msgstr ""
 
-msgctxt "#30036"
-msgid "in"
+msgctxt "#30036"  #30008 #30036 [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] #30035
+msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
 msgstr ""
 
-msgctxt "#30037"
-msgid "Next Episode in"
+msgctxt "#30037"  #30037 [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] #30035
+msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
 msgstr ""
 
 msgctxt "#30038"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -108,16 +108,16 @@ msgid "Close"
 msgstr "Fermer"
 
 msgctxt "#30035"
-msgid "seconds"
-msgstr "secondes"
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Continuer à regarder dans [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] secondes"
 
 msgctxt "#30036"
-msgid "in"
-msgstr "dans"
+msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "À suivre dans [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] secondes"
 
 msgctxt "#30037"
-msgid "Next Episode in"
-msgstr "Prochain épisode dans"
+msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Prochain épisode dans [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] secondes"
 
 msgctxt "#30038"
 msgid "Simple"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -106,16 +106,16 @@ msgid "Close"
 msgstr "Zatvori"
 
 msgctxt "#30035"
-msgid "seconds"
-msgstr "sekunde"
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Nastavite gledati u [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] sekunde"
 
 msgctxt "#30036"
-msgid "in"
-msgstr "u"
+msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Sljedeće u [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] sekunde"
 
 msgctxt "#30037"
-msgid "Next Episode in"
-msgstr "Sljedeća epizoda u"
+msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Sljedeća epizoda u [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] sekunde"
 
 msgctxt "#30038"
 msgid "Simple"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -107,16 +107,16 @@ msgid "Close"
 msgstr "Bezár"
 
 msgctxt "#30035"
-msgid "seconds"
-msgstr "másodperc múlva"
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Lejátszás folytatása indítása [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] másodperc múlva"
 
 msgctxt "#30036"
-msgid "in"
-msgstr "indítása"
+msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Következő rész indítása [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] másodperc múlva"
 
 msgctxt "#30037"
-msgid "Next Episode in"
-msgstr "Következő rész indítása"
+msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Következő rész indítása [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] másodperc múlva"
 
 msgctxt "#30038"
 msgid "Simple"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -106,16 +106,16 @@ msgid "Close"
 msgstr "Chiudi"
 
 msgctxt "#30035"
-msgid "seconds"
-msgstr "secondi"
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Continua a guardare fra [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] secondi"
 
 msgctxt "#30036"
-msgid "in"
-msgstr "fra"
+msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Prossimo fra [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] secondi"
 
 msgctxt "#30037"
-msgid "Next Episode in"
-msgstr "Prossimo episodio fra"
+msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Prossimo episodio fra [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] secondi"
 
 msgctxt "#30038"
 msgid "Simple"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -51,7 +51,7 @@ msgstr "Aantal afleveringen alvorens te vragen of er nog gekeken wordt"
 
 msgctxt "#30010"
 msgid "Continue watching"
-msgstr "Verderkijken"
+msgstr "Verder kijken"
 
 msgctxt "#30013"
 msgid "Include watched episodes"
@@ -106,16 +106,16 @@ msgid "Close"
 msgstr "Sluit"
 
 msgctxt "#30035"
-msgid "seconds"
-msgstr "seconden"
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Verder kijken in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconden"
 
 msgctxt "#30036"
-msgid "in"
-msgstr "in"
+msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Volgende aflevering in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconden"
 
 msgctxt "#30037"
-msgid "Next Episode in"
-msgstr "Volgende aflevering in"
+msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Volgende aflevering in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconden"
 
 msgctxt "#30038"
 msgid "Simple"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -106,16 +106,16 @@ msgid "Close"
 msgstr "Zamknij"
 
 msgctxt "#30035"
-msgid "seconds"
-msgstr "sekundy"
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Kontynuuj oglądanie za [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] sekundy"
 
 msgctxt "#30036"
-msgid "in"
-msgstr "za"
+msgid "Up next in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Kolejny za [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] sekundy"
 
 msgctxt "#30037"
-msgid "Next Episode in"
-msgstr "Następny odcinek za"
+msgid "Next episode in [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds"
+msgstr "Następny odcinek za [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] sekundy"
 
 msgctxt "#30038"
 msgid "Simple"

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -172,6 +172,9 @@ def get_global_setting(setting):
     return result.get('result', {}).get('value')
 
 
-def localize(string_id):
+def localize(string_id, **kwargs):
     ''' Return the translated string from the .po language files, optionally translating variables '''
+    if kwargs:
+        from string import Formatter
+        return Formatter().vformat(ADDON.getLocalizedString(string_id), (), SafeDict(**kwargs))
     return ADDON.getLocalizedString(string_id)

--- a/resources/skins/default/1080i/script-upnext-stillwatching-simple.xml
+++ b/resources/skins/default/1080i/script-upnext-stillwatching-simple.xml
@@ -39,7 +39,7 @@
                         <itemgap>10</itemgap>
                         <align>left</align>
                         <control type="button" id="10">
-                            <label>    $ADDON[service.upnext 30010]</label>
+                            <label>    $LOCALIZE[30010]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -59,7 +59,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="11">
-                            <label>    $ADDON[service.upnext 30010] $ADDON[service.upnext 30036] [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] $ADDON[service.upnext 30035]</label>
+                            <label>    $LOCALIZE[30035]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -79,7 +79,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="3013">
-                            <label>$ADDON[service.upnext 30034]</label>
+                            <label>$LOCALIZE[30034]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>
@@ -104,7 +104,7 @@
                             <font>font32_title</font>
                             <textcolor>eeffffff</textcolor>
                             <shadowcolor>00000000</shadowcolor>
-                            <label>[CAPITALIZE]$ADDON[service.upnext 30024][/CAPITALIZE]</label>
+                            <label>[CAPITALIZE]$LOCALIZE[30024][/CAPITALIZE]</label>
                         </control>
                     </control>
                     <control type="image">

--- a/resources/skins/default/1080i/script-upnext-stillwatching-simple.xml
+++ b/resources/skins/default/1080i/script-upnext-stillwatching-simple.xml
@@ -39,7 +39,7 @@
                         <itemgap>10</itemgap>
                         <align>left</align>
                         <control type="button" id="10">
-                            <label>    $LOCALIZE[30010]</label>
+                            <label>    $ADDON[service.upnext 30010]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -59,7 +59,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="11">
-                            <label>    $LOCALIZE[30035]</label>
+                            <label>    $ADDON[service.upnext 30035]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -79,7 +79,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="3013">
-                            <label>$LOCALIZE[30034]</label>
+                            <label>$ADDON[service.upnext 30034]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>
@@ -104,7 +104,7 @@
                             <font>font32_title</font>
                             <textcolor>eeffffff</textcolor>
                             <shadowcolor>00000000</shadowcolor>
-                            <label>[CAPITALIZE]$LOCALIZE[30024][/CAPITALIZE]</label>
+                            <label>[CAPITALIZE]$ADDON[service.upnext 30024][/CAPITALIZE]</label>
                         </control>
                     </control>
                     <control type="image">

--- a/resources/skins/default/1080i/script-upnext-stillwatching.xml
+++ b/resources/skins/default/1080i/script-upnext-stillwatching.xml
@@ -97,7 +97,7 @@
                         <font>font30_title</font>
                         <textcolor>ffffffff</textcolor>
                         <shadowcolor>00000000</shadowcolor>
-                        <label>[CAPITALIZE]$LOCALIZE[30024][/CAPITALIZE]</label>
+                        <label>[CAPITALIZE]$ADDON[service.upnext 30024][/CAPITALIZE]</label>
                     </control>
                     <!-- Details -->
                     <control type="grouplist">
@@ -157,7 +157,7 @@
                         <bottom>20</bottom>
                         <itemgap>10</itemgap>
                         <control type="button" id="10">
-                            <label>    $LOCALIZE[30010]</label>
+                            <label>    $ADDON[service.upnext 30010]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -177,7 +177,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="11">
-                            <label>    $LOCALIZE[30035]</label>
+                            <label>    $ADDON[service.upnext 30035]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -197,7 +197,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="3013">
-                            <label>$LOCALIZE[30034]</label>
+                            <label>$ADDON[service.upnext 30034]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>

--- a/resources/skins/default/1080i/script-upnext-stillwatching.xml
+++ b/resources/skins/default/1080i/script-upnext-stillwatching.xml
@@ -97,7 +97,7 @@
                         <font>font30_title</font>
                         <textcolor>ffffffff</textcolor>
                         <shadowcolor>00000000</shadowcolor>
-                        <label>[CAPITALIZE]$ADDON[service.upnext 30024][/CAPITALIZE]</label>
+                        <label>[CAPITALIZE]$LOCALIZE[30024][/CAPITALIZE]</label>
                     </control>
                     <!-- Details -->
                     <control type="grouplist">
@@ -157,7 +157,7 @@
                         <bottom>20</bottom>
                         <itemgap>10</itemgap>
                         <control type="button" id="10">
-                            <label>    $ADDON[service.upnext 30010]</label>
+                            <label>    $LOCALIZE[30010]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -177,7 +177,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="11">
-                            <label>    $ADDON[service.upnext 30010] $ADDON[service.upnext 30036] [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] $ADDON[service.upnext 30035]</label>
+                            <label>    $LOCALIZE[30035]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -197,7 +197,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="3013">
-                            <label>$ADDON[service.upnext 30034]</label>
+                            <label>$LOCALIZE[30034]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>

--- a/resources/skins/default/1080i/script-upnext-upnext-simple.xml
+++ b/resources/skins/default/1080i/script-upnext-upnext-simple.xml
@@ -39,7 +39,7 @@
                         <itemgap>10</itemgap>
                         <align>left</align>
                         <control type="button" id="10">
-                            <label>    $ADDON[service.upnext 30049]</label>
+                            <label>    $LOCALIZE[30049]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -59,7 +59,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="11">
-                            <label>    $ADDON[service.upnext 30037] [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] $ADDON[service.upnext 30035]</label>
+                            <label>    $LOCALIZE[30037]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -79,7 +79,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="3013">
-                            <label>$ADDON[service.upnext 30034]</label>
+                            <label>$LOCALIZE[30034]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>

--- a/resources/skins/default/1080i/script-upnext-upnext-simple.xml
+++ b/resources/skins/default/1080i/script-upnext-upnext-simple.xml
@@ -39,7 +39,7 @@
                         <itemgap>10</itemgap>
                         <align>left</align>
                         <control type="button" id="10">
-                            <label>    $LOCALIZE[30049]</label>
+                            <label>    $ADDON[service.upnext 30049]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -59,7 +59,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="11">
-                            <label>    $LOCALIZE[30037]</label>
+                            <label>    $ADDON[service.upnext 30037]</label>
                             <onclick>SendClick(3012)</onclick>
                             <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                             <height>56</height>
@@ -79,7 +79,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="3013">
-                            <label>$LOCALIZE[30034]</label>
+                            <label>$ADDON[service.upnext 30034]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>

--- a/resources/skins/default/1080i/script-upnext-upnext.xml
+++ b/resources/skins/default/1080i/script-upnext-upnext.xml
@@ -97,7 +97,7 @@
                         <font>font25_title</font>
                         <textcolor>eeffffff</textcolor>
                         <shadowcolor>00000000</shadowcolor>
-                        <label>$ADDON[service.upnext 30008] $ADDON[service.upnext 30036] [COLOR FFFF4081]$INFO[Player.TimeRemaining(ss),,][/COLOR] $ADDON[service.upnext 30035]</label>
+                        <label>$LOCALIZE[#30036]</label>
                         <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                     </control>
                     <control type="label">
@@ -107,7 +107,7 @@
                         <font>font25_title</font>
                         <textcolor>eeffffff</textcolor>
                         <shadowcolor>00000000</shadowcolor>
-                        <label>$ADDON[service.upnext 30008]</label>
+                        <label>$LOCALIZE[30008]</label>
                         <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                     </control>
                     <!-- Details -->
@@ -162,7 +162,7 @@
                         <bottom>20</bottom>
                         <itemgap>10</itemgap>
                         <control type="button" id="3012">
-                            <label>    $ADDON[service.upnext 30006]</label>
+                            <label>    $LOCALIZE[30006]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>
@@ -180,7 +180,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="3013">
-                            <label>$ADDON[service.upnext 30034]</label>
+                            <label>$LOCALIZE[30034]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>

--- a/resources/skins/default/1080i/script-upnext-upnext.xml
+++ b/resources/skins/default/1080i/script-upnext-upnext.xml
@@ -97,7 +97,7 @@
                         <font>font25_title</font>
                         <textcolor>eeffffff</textcolor>
                         <shadowcolor>00000000</shadowcolor>
-                        <label>$LOCALIZE[#30036]</label>
+                        <label>$ADDON[service.upnext 30036]</label>
                         <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
                     </control>
                     <control type="label">
@@ -107,7 +107,7 @@
                         <font>font25_title</font>
                         <textcolor>eeffffff</textcolor>
                         <shadowcolor>00000000</shadowcolor>
-                        <label>$LOCALIZE[30008]</label>
+                        <label>$ADDON[service.upnext 30008]</label>
                         <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
                     </control>
                     <!-- Details -->
@@ -162,7 +162,7 @@
                         <bottom>20</bottom>
                         <itemgap>10</itemgap>
                         <control type="button" id="3012">
-                            <label>    $LOCALIZE[30006]</label>
+                            <label>    $ADDON[service.upnext 30006]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>
@@ -180,7 +180,7 @@
                             <pulseonselect>no</pulseonselect>
                         </control>
                         <control type="button" id="3013">
-                            <label>$LOCALIZE[30034]</label>
+                            <label>$ADDON[service.upnext 30034]</label>
                             <height>56</height>
                             <width min="50">auto</width>
                             <font>font20_title</font>


### PR DESCRIPTION
Since some languages do not translate like most western languages
(composed of substrings) it is better to translate sentences, rather
than substrings.

This is required for Korean and/or Japanese translations.

But it is generally a better practice anyway.

This fixes #108 