### PR TITLE
Restructure some code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export PYTHONPATH := $(CURDIR):$(CURDIR)/test
+export PYTHONPATH := $(CURDIR):$(CURDIR)/test/
 PYTHON := python
 
 name = $(shell xmllint --xpath 'string(/addon/@id)' addon.xml)

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -60,8 +60,8 @@ msgid "Include watched episodes"
 msgstr "Gesehene Episoden mit einschließen"
 
 msgctxt "#30014"
-msgid "Disable Up Next (restart required)"
-msgstr "Up Next deaktivieren (benötigt Neustart)"
+msgid "Disable Up Next"
+msgstr "Up Next deaktivieren"
 
 msgctxt "#30017"
 msgid "Automatically play short videos"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -58,7 +58,7 @@ msgid "Include watched episodes"
 msgstr ""
 
 msgctxt "#30014"
-msgid "Disable Up Next (restart required)"
+msgid "Disable Up Next"
 msgstr ""
 
 msgctxt "#30017"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -60,8 +60,8 @@ msgid "Include watched episodes"
 msgstr "Inclure les épisodes visionnés"
 
 msgctxt "#30014"
-msgid "Disable Up Next (restart required)"
-msgstr "Désactiver Up Next (redémarrage requis)"
+msgid "Disable Up Next"
+msgstr "Désactiver Up Next"
 
 msgctxt "#30017"
 msgid "Automatically play short videos"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -58,8 +58,8 @@ msgid "Include watched episodes"
 msgstr "Uključi gledane epizode"
 
 msgctxt "#30014"
-msgid "Disable Up Next (restart required)"
-msgstr "Onemogući Up Next (restart potreban)"
+msgid "Disable Up Next"
+msgstr "Onemogući Up Next"
 
 msgctxt "#30017"
 msgid "Automatically play short videos"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -58,8 +58,8 @@ msgid "Include watched episodes"
 msgstr "Megnézett epizódokat is beleértve"
 
 msgctxt "#30014"
-msgid "Disable Up Next (restart required)"
-msgstr "Up Next kikapcsolása (restart kell hozzá)"
+msgid "Disable Up Next"
+msgstr "Up Next kikapcsolása"
 
 msgctxt "#30017"
 msgid "Automatically play short videos"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -58,8 +58,8 @@ msgid "Include watched episodes"
 msgstr "Includi episodi guardati"
 
 msgctxt "#30014"
-msgid "Disable Up Next (restart required)"
-msgstr "Disabilita Up Next (riavvio richiesto)"
+msgid "Disable Up Next"
+msgstr "Disabilita Up Next"
 
 msgctxt "#30017"
 msgid "Automatically play short videos"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -58,8 +58,8 @@ msgid "Include watched episodes"
 msgstr "Ook op bekeken afleveringen toepassen"
 
 msgctxt "#30014"
-msgid "Disable Up Next (restart required)"
-msgstr "Up Next uitschakelen (herstarten vereist)"
+msgid "Disable Up Next"
+msgstr "Up Next uitschakelen"
 
 msgctxt "#30017"
 msgid "Automatically play short videos"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -58,8 +58,8 @@ msgid "Include watched episodes"
 msgstr "Uwzględnij oglądane odcinki"
 
 msgctxt "#30014"
-msgid "Disable Up Next (restart required)"
-msgstr "Wyłącz Up Next (wymagane ponowne uruchomienie)"
+msgid "Disable Up Next"
+msgstr "Wyłącz Up Next"
 
 msgctxt "#30017"
 msgid "Automatically play short videos"

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -2,8 +2,8 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-import xbmc
-from . import utils
+from xbmc import sleep
+from .utils import event, get_setting, jsonrpc, log as ulog
 
 
 class Api:
@@ -18,7 +18,7 @@ class Api:
 
     def log(self, msg, level=2):
         ''' Log wrapper '''
-        utils.log(msg, name=self.__class__.__name__, level=level)
+        ulog(msg, name=self.__class__.__name__, level=level)
 
     def has_addon_data(self):
         return self.data
@@ -33,10 +33,10 @@ class Api:
 
     @staticmethod
     def play_kodi_item(episode):
-        utils.jsonrpc(method='Player.Open', id=0, params=dict(item=dict(episodeid=episode.get('episodeid'))))
+        jsonrpc(method='Player.Open', id=0, params=dict(item=dict(episodeid=episode.get('episodeid'))))
 
     def get_next_in_playlist(self, position):
-        result = utils.jsonrpc(method='Playlist.GetItems', params=dict(
+        result = jsonrpc(method='Playlist.GetItems', params=dict(
             playlistid=1,
             limits=dict(start=position + 1, end=position + 2),
             properties=['art', 'dateadded', 'episode', 'file', 'firstaired', 'lastplayed',
@@ -61,7 +61,7 @@ class Api:
 
     def play_addon_item(self):
         self.log('sending %(encoding)s data to addon to play: %(play_info)s' % dict(encoding=self.encoding, **self.data), 2)
-        utils.event(message=self.data.get('id'), data=self.data.get('play_info'), sender='upnextprovider', encoding=self.encoding)
+        event(message=self.data.get('id'), data=self.data.get('play_info'), sender='upnextprovider', encoding=self.encoding)
 
     def handle_addon_lookup_of_next_episode(self):
         if not self.data:
@@ -76,13 +76,13 @@ class Api:
         return self.data.get('current_episode')
 
     def notification_time(self):
-        return self.data.get('notification_time') or utils.settings('autoPlaySeasonTime')
+        return self.data.get('notification_time') or get_setting('autoPlaySeasonTime')
 
     def get_now_playing(self):
         # Seems to work too fast loop whilst waiting for it to become active
         result = dict()
         while not result.get('result'):
-            result = utils.jsonrpc(method='Player.GetActivePlayers')
+            result = jsonrpc(method='Player.GetActivePlayers')
             self.log('Got active player %s' % result, 2)
 
         if not result.get('result'):
@@ -92,7 +92,7 @@ class Api:
 
         # Get details of the playing media
         self.log('Getting details of now playing media', 2)
-        result = utils.jsonrpc(method='Player.GetItem', params=dict(
+        result = jsonrpc(method='Player.GetItem', params=dict(
             playerid=playerid,
             properties=['episode', 'genre', 'playcount', 'plotoutline', 'season', 'showtitle', 'tvshowid'],
         ))
@@ -100,7 +100,7 @@ class Api:
         return result
 
     def handle_kodi_lookup_of_episode(self, tvshowid, current_file, include_watched, current_episode_id):
-        result = utils.jsonrpc(method='VideoLibrary.GetEpisodes', params=dict(
+        result = jsonrpc(method='VideoLibrary.GetEpisodes', params=dict(
             tvshowid=tvshowid,
             properties=['art', 'dateadded', 'episode', 'file', 'firstaired', 'lastplayed',
                         'playcount', 'plot', 'rating', 'resume', 'runtime', 'season',
@@ -112,13 +112,13 @@ class Api:
             return None
 
         self.log('Got details of next up episode %s' % result, 2)
-        xbmc.sleep(100)
+        sleep(100)
 
         # Find the next unwatched and the newest added episodes
         return self.find_next_episode(result, current_file, include_watched, current_episode_id)
 
     def handle_kodi_lookup_of_current_episode(self, tvshowid, current_episode_id):
-        result = utils.jsonrpc(method='VideoLibrary.GetEpisodes', params=dict(
+        result = jsonrpc(method='VideoLibrary.GetEpisodes', params=dict(
             tvshowid=tvshowid,
             properties=['art', 'dateadded', 'episode', 'file', 'firstaired', 'lastplayed',
                         'playcount', 'plot', 'rating', 'resume', 'runtime', 'season',
@@ -130,7 +130,7 @@ class Api:
             return None
 
         self.log('Find current episode called', 2)
-        xbmc.sleep(100)
+        sleep(100)
 
         # Find the next unwatched and the newest added episodes
         episodes = result.get('result', {}).get('episodes', [])
@@ -146,7 +146,7 @@ class Api:
 
     @staticmethod
     def showtitle_to_id(title):
-        result = utils.jsonrpc(method='VideoLibrary.GetTVShows', id='libTvShows', params=dict(properties=['title']))
+        result = jsonrpc(method='VideoLibrary.GetTVShows', id='libTvShows', params=dict(properties=['title']))
 
         for tvshow in result.get('result', {}).get('tvshows', []):
             if tvshow.get('label') == title:
@@ -157,7 +157,7 @@ class Api:
     def get_episode_id(showid, show_season, show_episode):
         show_season = int(show_season)
         show_episode = int(show_episode)
-        result = utils.jsonrpc(method='VideoLibrary.GetEpisodes', params=dict(
+        result = jsonrpc(method='VideoLibrary.GetEpisodes', params=dict(
             properties=['episode', 'season'],
             tvshowid=int(showid),
         ))

--- a/resources/lib/developer.py
+++ b/resources/lib/developer.py
@@ -2,9 +2,9 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-import xbmc
-from . import pages
-from . import utils
+from xbmc import Player, sleep
+from .pages import set_up_developer_pages
+from .utils import clear_property, get_setting, load_test_data, set_property
 
 
 class Developer:
@@ -15,35 +15,36 @@ class Developer:
 
     @staticmethod
     def developer_play_back():
-        episode = utils.load_test_data()
+        episode = load_test_data()
         next_up_page, next_up_page_simple, still_watching_page, still_watching_page_simple = (
-            pages.set_up_developer_pages(episode))
-        if utils.settings('windowMode') == '0':
+            set_up_developer_pages(episode))
+        window_mode = int(get_setting('windowMode'))
+        if window_mode == 0:
             next_up_page.show()
-        elif utils.settings('windowMode') == '1':
+        elif window_mode == 1:
             next_up_page_simple.show()
-        elif utils.settings('windowMode') == '2':
+        elif window_mode == 2:
             still_watching_page.show()
-        elif utils.settings('windowMode') == '3':
+        elif window_mode == 3:
             still_watching_page_simple.show()
-        utils.window('service.upnext.dialog', 'true')
+        set_property('service.upnext.dialog', 'true')
 
-        player = xbmc.Player()
+        player = Player()
         while (player.isPlaying() and not next_up_page.is_cancel()
                and not next_up_page.is_watch_now() and not still_watching_page.is_still_watching()
                and not still_watching_page.is_cancel()):
-            xbmc.sleep(100)
+            sleep(100)
             next_up_page.update_progress_control()
             next_up_page_simple.update_progress_control()
             still_watching_page.update_progress_control()
             still_watching_page_simple.update_progress_control()
 
-        if utils.settings('windowMode') == '0':
+        if window_mode == 0:
             next_up_page.close()
-        elif utils.settings('windowMode') == '1':
+        elif window_mode == 1:
             next_up_page_simple.close()
-        elif utils.settings('windowMode') == '2':
+        elif window_mode == 2:
             still_watching_page.close()
-        elif utils.settings('windowMode') == '3':
+        elif window_mode == 3:
             still_watching_page_simple.close()
-        utils.window('service.upnext.dialog', clear=True)
+        clear_property('service.upnext.dialog')

--- a/resources/lib/pages.py
+++ b/resources/lib/pages.py
@@ -2,32 +2,32 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from . import utils
 from .stillwatching import StillWatching
 from .upnext import UpNext
+from .utils import addon_path, calculate_progress_steps, get_setting
 
 
 def set_up_pages():
-    if utils.settings('simpleMode') == '0':
-        next_up_page = UpNext('script-upnext-upnext-simple.xml', utils.ADDON_PATH, 'default', '1080i')
-        still_watching_page = StillWatching('script-upnext-stillwatching-simple.xml', utils.ADDON_PATH, 'default', '1080i')
+    if get_setting('simpleMode') == '0':
+        next_up_page = UpNext('script-upnext-upnext-simple.xml', addon_path(), 'default', '1080i')
+        still_watching_page = StillWatching('script-upnext-stillwatching-simple.xml', addon_path(), 'default', '1080i')
     else:
-        next_up_page = UpNext('script-upnext-upnext.xml', utils.ADDON_PATH, 'default', '1080i')
-        still_watching_page = StillWatching('script-upnext-stillwatching.xml', utils.ADDON_PATH, 'default', '1080i')
+        next_up_page = UpNext('script-upnext-upnext.xml', addon_path(), 'default', '1080i')
+        still_watching_page = StillWatching('script-upnext-stillwatching.xml', addon_path(), 'default', '1080i')
     return next_up_page, still_watching_page
 
 
 def set_up_developer_pages(episode):
-    next_up_page_simple = UpNext('script-upnext-upnext-simple.xml', utils.ADDON_PATH, 'default', '1080i')
-    still_watching_page_simple = StillWatching('script-upnext-stillwatching-simple.xml', utils.ADDON_PATH, 'default', '1080i')
-    next_up_page = UpNext('script-upnext-upnext.xml', utils.ADDON_PATH, 'default', '1080i')
-    still_watching_page = StillWatching('script-upnext-stillwatching.xml', utils.ADDON_PATH, 'default', '1080i')
+    next_up_page_simple = UpNext('script-upnext-upnext-simple.xml', addon_path(), 'default', '1080i')
+    still_watching_page_simple = StillWatching('script-upnext-stillwatching-simple.xml', addon_path(), 'default', '1080i')
+    next_up_page = UpNext('script-upnext-upnext.xml', addon_path(), 'default', '1080i')
+    still_watching_page = StillWatching('script-upnext-stillwatching.xml', addon_path(), 'default', '1080i')
     next_up_page.set_item(episode)
     next_up_page_simple.set_item(episode)
     still_watching_page.set_item(episode)
     still_watching_page_simple.set_item(episode)
-    notification_time = utils.settings('autoPlaySeasonTime')
-    progress_step_size = utils.calculate_progress_steps(notification_time)
+    notification_time = get_setting('autoPlaySeasonTime')
+    progress_step_size = calculate_progress_steps(notification_time)
     next_up_page.set_progress_step_size(progress_step_size)
     next_up_page_simple.set_progress_step_size(progress_step_size)
     still_watching_page.set_progress_step_size(progress_step_size)

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -2,14 +2,14 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-import xbmc
-from . import utils
+from xbmc import getCondVisibility, Player, sleep
 from .api import Api
 from .developer import Developer
 from .state import State
+from .utils import get_setting
 
 
-class Player(xbmc.Player):
+class UpNextPlayer(Player):
     ''' Service class for playback monitoring '''
     last_file = None
     track = False
@@ -18,7 +18,7 @@ class Player(xbmc.Player):
         self.api = Api()
         self.state = State()
         self.developer = Developer()
-        xbmc.Player.__init__(self)
+        Player.__init__(self)
 
     def set_last_file(self, filename):
         self.state.last_file = filename
@@ -34,11 +34,11 @@ class Player(xbmc.Player):
 
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
         ''' Will be called when kodi starts playing a file '''
-        xbmc.sleep(5000)  # Delay for slower devices, should really use onAVStarted for Leia
-        if not xbmc.getCondVisibility('videoplayer.content(episodes)'):
+        sleep(5000)  # Delay for slower devices, should really use onAVStarted for Leia
+        if not getCondVisibility('videoplayer.content(episodes)'):
             return
         self.state.track = True
-        if utils.settings('developerMode') == 'true':
+        if bool(get_setting('developerMode') == 'true'):
             self.developer.developer_play_back()
 
     def onPlayBackPaused(self):  # pylint: disable=invalid-name

--- a/resources/lib/playitem.py
+++ b/resources/lib/playitem.py
@@ -2,11 +2,11 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-import xbmc
-from . import utils
+from xbmc import PlayList, PLAYLIST_VIDEO
 from .api import Api
 from .player import Player
 from .state import State
+from .utils import log as ulog
 
 
 class PlayItem:
@@ -19,7 +19,7 @@ class PlayItem:
         self.state = State()
 
     def log(self, msg, level=2):
-        utils.log(msg, name=self.__class__.__name__, level=level)
+        ulog(msg, name=self.__class__.__name__, level=level)
 
     def get_episode(self):
         current_file = self.player.getPlayingFile()
@@ -41,9 +41,9 @@ class PlayItem:
         return episode
 
     def get_next(self):
-        playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
+        playlist = PlayList(PLAYLIST_VIDEO)
         position = playlist.getposition()
-        # A playlist with only one element has no next item and xbmc.PlayList().getposition() starts counting from zero
+        # A playlist with only one element has no next item and PlayList().getposition() starts counting from zero
         if playlist.size() > 1 and position < (playlist.size() - 1):
             return self.api.get_next_in_playlist(position)
         return False

--- a/resources/lib/state.py
+++ b/resources/lib/state.py
@@ -2,7 +2,7 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from . import utils
+from .utils import get_setting
 
 
 # keeps track of the state parameters
@@ -11,11 +11,11 @@ class State:
 
     def __init__(self):
         self.__dict__ = self._shared_state
-        self.play_mode = utils.settings('autoPlayMode')
-        self.short_play_mode = utils.settings('shortPlayMode')
-        self.short_play_notification = utils.settings('shortPlayNotification')
-        self.short_play_length = int(utils.settings('shortPlayLength')) * 60
-        self.include_watched = utils.settings('includeWatched') == 'true'
+        self.play_mode = get_setting('autoPlayMode')
+        self.short_play_mode = get_setting('shortPlayMode')
+        self.short_play_notification = get_setting('shortPlayNotification')
+        self.short_play_length = int(get_setting('shortPlayLength')) * 60
+        self.include_watched = bool(get_setting('includeWatched') == 'true')
         self.current_tv_show_id = None
         self.current_episode_id = None
         self.tv_show_id = None

--- a/resources/lib/stillwatching.py
+++ b/resources/lib/stillwatching.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals
 from platform import machine
-import xbmcgui
+from xbmcgui import WindowXMLDialog
 from .statichelper import from_unicode
 
 ACTION_PLAYER_STOP = 13
@@ -11,7 +11,7 @@ ACTION_NAV_BACK = 92
 OS_MACHINE = machine()
 
 
-class StillWatching(xbmcgui.WindowXMLDialog):
+class StillWatching(WindowXMLDialog):
     item = None
     cancel = False
     stillwatching = False
@@ -23,9 +23,9 @@ class StillWatching(xbmcgui.WindowXMLDialog):
         self.action_exitkeys_id = [10, 13]
         self.progress_control = None
         if OS_MACHINE[0:5] == 'armv7':
-            xbmcgui.WindowXMLDialog.__init__(self)
+            WindowXMLDialog.__init__(self)
         else:
-            xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+            WindowXMLDialog.__init__(self, *args, **kwargs)
 
     def onInit(self):  # pylint: disable=invalid-name
         self.set_info()

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -3,17 +3,17 @@
 
 from __future__ import absolute_import, division, unicode_literals
 from platform import machine
-import xbmc
-import xbmcgui
-from . import utils
+from xbmc import Player
+from xbmcgui import WindowXMLDialog
 from .statichelper import from_unicode
+from .utils import get_setting, localize
 
 ACTION_PLAYER_STOP = 13
 ACTION_NAV_BACK = 92
 OS_MACHINE = machine()
 
 
-class UpNext(xbmcgui.WindowXMLDialog):
+class UpNext(WindowXMLDialog):
     item = None
     cancel = False
     watchnow = False
@@ -24,18 +24,18 @@ class UpNext(xbmcgui.WindowXMLDialog):
         self.action_exitkeys_id = [10, 13]
         self.progress_control = None
         if OS_MACHINE[0:5] == 'armv7':
-            xbmcgui.WindowXMLDialog.__init__(self)
+            WindowXMLDialog.__init__(self)
         else:
-            xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+            WindowXMLDialog.__init__(self, *args, **kwargs)
 
     def onInit(self):  # pylint: disable=invalid-name
         self.set_info()
         self.prepare_progress_control()
 
-        if utils.settings('stopAfterClose') == 'true':
-            self.getControl(3013).setLabel(utils.localize(30033))  # Stop
+        if bool(get_setting('stopAfterClose') == 'true'):
+            self.getControl(3013).setLabel(localize(30033))  # Stop
         else:
-            self.getControl(3013).setLabel(utils.localize(30034))  # Close
+            self.getControl(3013).setLabel(localize(30034))  # Close
 
     def set_info(self):
         episode_info = '%(season)sx%(episode)s.' % self.item
@@ -108,8 +108,8 @@ class UpNext(xbmcgui.WindowXMLDialog):
             self.close()
         elif controlId == 3013:  # Close / Stop
             self.set_cancel(True)
-            if utils.settings('stopAfterClose') == 'true':
-                xbmc.Player().stop()
+            if bool(get_setting('stopAfterClose') == 'true'):
+                Player().stop()
             self.close()
 
     def onAction(self, action):  # pylint: disable=invalid-name

--- a/service.py
+++ b/service.py
@@ -2,7 +2,7 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from resources.lib.monitor import Monitor
+from resources.lib.monitor import UpNextMonitor
 
 # Start the monitor
-Monitor().run()
+UpNextMonitor().run()

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
+import AddonSignals
 from resources.lib import utils
 
 xbmc = __import__('xbmc')
@@ -51,7 +52,6 @@ class TestEncoding(unittest.TestCase):
         self.assertEqual(encoding, 'base64')
 
     def test_from_addon_signals(self):
-        import AddonSignals
         data = 'Fòöbàr'
 
         base64_encoded_data = 'IkZcdTAwZjJcdTAwZjZiXHUwMGUwciI='
@@ -62,7 +62,6 @@ class TestEncoding(unittest.TestCase):
         self.assertEqual(encoding, 'base64')
 
     def test_to_addon_signals(self):
-        import AddonSignals
         data = 'Fòöbàr'
 
         base64_encoded_data = 'IkZcdTAwZjJcdTAwZjZiXHUwMGUwciI='


### PR DESCRIPTION
These are the non-impacting changes from PR #100.

This PR includes:
- Selectively import classes and functions from modules
- Rename 'settings()' into 'get_setting()'
- Change 'window()' into 'clear_property()', 'get_property()' and 'set_property()'
- Use Addon instance on demand so settings are updated instantly
- No longer require a restart/reboot for settings to be applied