### PR TITLE
Remove shortPlay functionality

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,4 +12,5 @@ disable=
     too-many-arguments,
     too-many-function-args,
     too-many-instance-attributes,
+    too-many-return-statements,
     useless-super-delegation,

--- a/resources/lib/state.py
+++ b/resources/lib/state.py
@@ -12,9 +12,6 @@ class State:
     def __init__(self):
         self.__dict__ = self._shared_state
         self.play_mode = get_setting('autoPlayMode')
-        self.short_play_mode = get_setting('shortPlayMode')
-        self.short_play_notification = get_setting('shortPlayNotification')
-        self.short_play_length = int(get_setting('shortPlayLength')) * 60
         self.include_watched = bool(get_setting('includeWatched') == 'true')
         self.current_tv_show_id = None
         self.current_episode_id = None

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -17,9 +17,6 @@
         <setting label="30621" type="slider" id="autoPlayTimeL" default="50" range="0,5,120" option="int" visible="eq(-5,true)"/>
         <setting label="30623" type="slider" id="autoPlayTimeXL" default="60" range="0,5,120" option="int" visible="eq(-6,true)"/>
         <!-- Old unused settings -->
-        <setting label="30017" type="bool" id="shortPlayMode" default="false" visible="false"/>
-        <setting label="30018" type="number" id="shortPlayLength" default="10" visible="false"/>
-        <setting label="30019" type="bool" id="shortPlayNotification" default="true" visible="false"/>
         <setting label="30032" type="bool" id="enablePlaylist" visible="false" enable="false"/> <!-- To avoid log spam just disable setting -->
     </category>
     <category label="30700"> <!-- Expert -->


### PR DESCRIPTION
This was already disabled from the settings after #100 was merged.
So I guess we can remove this functionality.

Users can now only disable the Up Next pop-up for video's smaller than
10mins by configuring a notification time of 0.