### PR TITLE
Various fixes to translations

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -31,18 +31,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Wiedergabe fortsetzen"
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "Spiele kurze Videos automatisch ab"
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "Maximale Länge für das Abspielen von kurzen Videos (in Minuten)"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "Zeige Benachrichtigung bei automatischer Wiedergabe von kurzen Videos"
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "Noch da?"
@@ -118,7 +106,7 @@ msgid "Set the display mode for the notifications"
 msgstr "Anzeigemodus der Benachrichtigung"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr "Wiedergabe nach dem Schließen des Dialogs stoppen"
 
 msgctxt "#30600"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -30,18 +30,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr ""
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr ""
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr ""
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr ""
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr ""
@@ -117,7 +105,7 @@ msgid "Set the display mode for the notifications"
 msgstr ""
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr ""
 
 msgctxt "#30600"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -31,18 +31,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Continuer à regarder"
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "Lire automatiquement de courtes vidéos"
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "Durée maximale pour la lecture automatique de vidéos courtes (en minutes)"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "Afficher la notification à l’écran pendant la lecture automatique de vidéos courtes"
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "Toujours là ?"
@@ -118,7 +106,7 @@ msgid "Set the display mode for the notifications"
 msgstr "Définir le mode d’affichage des notifications"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr "Arrêter la lecture à la fermeture de la boîte de dialogue"
 
 msgctxt "#30600"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -33,18 +33,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Nastavite gledati"
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "Automatski reproduciraj kratke videozapise"
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "Maksimalna dužina automatske kratke reprodukcije videozapisa (u minutama)"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "Prikažite obavijest na zaslonu tijekom kratkog videozapisa"
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "Ste još tamo?"
@@ -120,7 +108,7 @@ msgid "Set the display mode for the notifications"
 msgstr "Postavite način prikaza za obavijesti"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr "Zaustavljanje reprodukcije kod zatvaranja dijaloškog okvira"
 
 msgctxt "#30600"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -29,18 +29,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Lejátszás folytatása"
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "Rövid videók automatikus lejátszása"
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "Rövid videók max. hossza amit automatikusan lejátszik"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "Rövid videóknál jelzés bekapcsolása"
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "Még itt vagy?"
@@ -116,7 +104,7 @@ msgid "Set the display mode for the notifications"
 msgstr "Értesitések típusa"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr "Lejátszás megállítása ha bezárja az ablakot"
 
 msgctxt "#30600"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -30,18 +30,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Continua a guardare"
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "Riproduci automaticamente video brevi"
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "Lunghezza massima per la riproduzione automatica di video brevi (in minuti)"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "Mostra notifica sullo schermo durante la riproduzione automatica di video brevi"
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "Ancora qui?"
@@ -116,7 +104,7 @@ msgid "Set the display mode for the notifications"
 msgstr "Imposta la modalità di visualizzazione per le notifiche"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr "Fermare la riproduzione alla chiusura della finestra di dialogo"
 
 msgctxt "#30600"

--- a/resources/language/resource.language.ja_JP/strings.po
+++ b/resources/language/resource.language.ja_JP/strings.po
@@ -30,18 +30,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "続いて観る"
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "短いビデオは自動再生"
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "最長何分ぐらいが短いビデオでしょうか。"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "短いビデオを自動再生する際に通知を見せる。"
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "まだ観るの。"
@@ -98,22 +86,6 @@ msgctxt "#30044"
 msgid "Debug"
 msgstr "Debug"
 
-msgctxt "#30045"
-msgid "UpNext"
-msgstr "UpNext"
-
-msgctxt "#30046"
-msgid "UpNextSimple"
-msgstr "UpNextSimple"
-
-msgctxt "#30047"
-msgid "StillWatching"
-msgstr "StillWatching"
-
-msgctxt "#30048"
-msgid "StillWatchingSimple"
-msgstr "StillWatchingSimple"
-
 msgctxt "#30049"
 msgid "Next Episode"
 msgstr "次のエピソード"
@@ -133,7 +105,7 @@ msgid "Set the display mode for the notifications"
 msgstr "通知モード"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr "通知を閉じると再生を停止する。"
 
 msgctxt "#30600"

--- a/resources/language/resource.language.ko_KR/strings.po
+++ b/resources/language/resource.language.ko_KR/strings.po
@@ -30,18 +30,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "계속 봅니다."
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "짧은 비디오는 자동으로 재생합니다."
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "최대 몇 분 정도가 짧은 비디오일까요?"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "짧은 비디오를 자동재생할 때 알림창을 보여줍니다."
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "계속 보시렵니까?"
@@ -98,22 +86,6 @@ msgctxt "#30044"
 msgid "Debug"
 msgstr "Debug"
 
-msgctxt "#30045"
-msgid "UpNext"
-msgstr "UpNext"
-
-msgctxt "#30046"
-msgid "UpNextSimple"
-msgstr "UpNextSimple"
-
-msgctxt "#30047"
-msgid "StillWatching"
-msgstr "StillWatching"
-
-msgctxt "#30048"
-msgid "StillWatchingSimple"
-msgstr "StillWatchingSimple"
-
 msgctxt "#30049"
 msgid "Next Episode"
 msgstr "다음 에피소드"
@@ -133,7 +105,7 @@ msgid "Set the display mode for the notifications"
 msgstr "알림창을 어떻게 보여줄까요?"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr "알림창을 닫을 때 재생도 중지합니다."
 
 msgctxt "#30600"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -29,18 +29,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Verder kijken"
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "Korte video's automatisch afspelen"
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "Maximale lengte voor het automatisch afspelen van korte video's (in minuten)"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "Tijdens het automatisch afspelen van korte video's meldingen tonen"
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "Ben je er nog?"
@@ -51,11 +39,11 @@ msgstr "Ook op afspeellijsten toepassen"
 
 msgctxt "#30033"
 msgid "Stop"
-msgstr "Stop"
+msgstr "Stoppen"
 
 msgctxt "#30034"
 msgid "Close"
-msgstr "Sluit"
+msgstr "Sluiten"
 
 msgctxt "#30035"
 msgid "Continue watching in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
@@ -97,22 +85,6 @@ msgctxt "#30044"
 msgid "Debug"
 msgstr "Foutopsporing"
 
-msgctxt "#30045"
-msgid "UpNext"
-msgstr "UpNext"
-
-msgctxt "#30046"
-msgid "UpNextSimple"
-msgstr "UpNextSimple"
-
-msgctxt "#30047"
-msgid "StillWatching"
-msgstr "StillWatching"
-
-msgctxt "#30048"
-msgid "StillWatchingSimple"
-msgstr "StillWatchingSimple"
-
 msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Volgende aflevering"
@@ -132,8 +104,8 @@ msgid "Set the display mode for the notifications"
 msgstr "Schermmodus voor meldingen"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
-msgstr "Na het afsluiten stoppen met afspelen"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
+msgstr "Voorzie een knop \"Stoppen\" in plaats van \"Sluiten\""
 
 msgctxt "#30600"
 msgid "Behaviour"
@@ -145,15 +117,15 @@ msgstr "Functionaliteit"
 
 msgctxt "#30603"
 msgid "Default action when nothing selected"
-msgstr "Standaardactie als niets geselecteerd is"
+msgstr "Standaardactie bij geen keuze"
 
 msgctxt "#30605"
 msgid "Include already watched episodes"
-msgstr "Ook op reeds bekeken afleveringen toepassen"
+msgstr "Ook reeds bekeken afleveringen afspelen"
 
 msgctxt "#30607"
 msgid "Number of episodes before \"Still there?\" query"
-msgstr "Aantal afleveringen alvorens te vragen of er nog gekeken wordt"
+msgstr "Aantal afleveringen alvorens te vragen \"Ben je er nog?\""
 
 msgctxt "#30609"
 msgid "Duration in seconds for notification to be shown"
@@ -161,7 +133,7 @@ msgstr "Aantal seconden om vóór het einde te melden"
 
 msgctxt "#30611"
 msgid "Customize autoplay duration by episode length"
-msgstr "Autoplay melding aanpassen op basis van episode lengte"
+msgstr "Autoplay melding aanpassen op basis van afleveringlengte"
 
 msgctxt "#30613"
 msgid "All episodes  [COLOR gray]any length[/COLOR]"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -29,18 +29,6 @@ msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Kontynuuj oglądanie"
 
-msgctxt "#30017"
-msgid "Automatically play short videos"
-msgstr "Automatycznie odtwarzaj krótkie filmy"
-
-msgctxt "#30018"
-msgid "Maximum length for automatic short video play (in minutes)"
-msgstr "Maksymalna długość automatycznego odtwarzania krótkich filmów (w minutach)"
-
-msgctxt "#30019"
-msgid "Show on-screen notification during short video autoplay"
-msgstr "Pokaż powiadomienia na ekranie podczas krótkiego autoodtwarzania wideo"
-
 msgctxt "#30024"
 msgid "Still there?"
 msgstr "Wciąż jesteś?"
@@ -116,7 +104,7 @@ msgid "Set the display mode for the notifications"
 msgstr "Ustaw tryb wyświetlania powiadomień"
 
 msgctxt "#30505"
-msgid "Stop playback when closing dialog"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
 msgstr "Zatrzymaj odtwarzanie po zamknięciu okna dialogowego"
 
 msgctxt "#30600"

--- a/resources/skins/default/1080i/script-upnext-stillwatching-simple.xml
+++ b/resources/skins/default/1080i/script-upnext-stillwatching-simple.xml
@@ -104,7 +104,7 @@
                             <font>font32_title</font>
                             <textcolor>eeffffff</textcolor>
                             <shadowcolor>00000000</shadowcolor>
-                            <label>[CAPITALIZE]$ADDON[service.upnext 30024][/CAPITALIZE]</label>
+                            <label>$ADDON[service.upnext 30024]</label>
                         </control>
                     </control>
                     <control type="image">

--- a/resources/skins/default/1080i/script-upnext-stillwatching.xml
+++ b/resources/skins/default/1080i/script-upnext-stillwatching.xml
@@ -97,7 +97,7 @@
                         <font>font30_title</font>
                         <textcolor>ffffffff</textcolor>
                         <shadowcolor>00000000</shadowcolor>
-                        <label>[CAPITALIZE]$ADDON[service.upnext 30024][/CAPITALIZE]</label>
+                        <label>$ADDON[service.upnext 30024]</label>
                     </control>
                     <!-- Details -->
                     <control type="grouplist">


### PR DESCRIPTION
This PR includes:
- A better description of Close vs Stop button
- Remove unused strings and translations
- Do not use [CAPITALIZE] for title
- Fix a few Dutch translations