### PR TITLE
Fix various runtime exceptions

### DIFF
--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -150,6 +150,7 @@ class PlaybackManager:  # pylint: disable=invalid-name
             should_play_default = still_watching_page.is_still_watching()
             should_play_non_default = still_watching_page.is_still_watching()
         else:
+            # FIXME: This is a workaround until we handle this better (see comments in #142)
             return False, False
 
         if next_up_page.is_watch_now() or still_watching_page.is_still_watching():

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -149,6 +149,8 @@ class PlaybackManager:  # pylint: disable=invalid-name
             still_watching_page.close()
             should_play_default = still_watching_page.is_still_watching()
             should_play_non_default = still_watching_page.is_still_watching()
+        else:
+            return False, False
 
         if next_up_page.is_watch_now() or still_watching_page.is_still_watching():
             self.state.played_in_a_row = 1

--- a/resources/lib/stillwatching.py
+++ b/resources/lib/stillwatching.py
@@ -57,9 +57,11 @@ class StillWatching(WindowXMLDialog):
             self.setProperty('playcount', str(self.item.get('playcount', 0)))
 
     def prepare_progress_control(self):
-        self.progress_control = self.getControl(3014)
-        if self.progress_control is not None:
+        try:
+            self.progress_control = self.getControl(3014)
             self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
+        except RuntimeError:
+            pass
 
     def set_item(self, item):
         self.item = item
@@ -69,9 +71,11 @@ class StillWatching(WindowXMLDialog):
 
     def update_progress_control(self, remaining=None, endtime=None):
         self.current_progress_percent = self.current_progress_percent - self.progress_step_size
-        self.progress_control = self.getControl(3014)
-        if self.progress_control is not None:
+        try:
+            self.progress_control = self.getControl(3014)
             self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
+        except RuntimeError:
+            pass
         if remaining:
             self.setProperty('remaining', from_unicode('%02d' % remaining))
         if endtime:

--- a/resources/lib/stillwatching.py
+++ b/resources/lib/stillwatching.py
@@ -59,9 +59,10 @@ class StillWatching(WindowXMLDialog):
     def prepare_progress_control(self):
         try:
             self.progress_control = self.getControl(3014)
-            self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
-        except RuntimeError:
+        except RuntimeError: # Occurs when skin does not include progress control
             pass
+        else:
+            self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
 
     def set_item(self, item):
         self.item = item
@@ -73,9 +74,11 @@ class StillWatching(WindowXMLDialog):
         self.current_progress_percent = self.current_progress_percent - self.progress_step_size
         try:
             self.progress_control = self.getControl(3014)
-            self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
-        except RuntimeError:
+        except RuntimeError: # Occurs when skin does not include progress control
             pass
+        else:
+            self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
+
         if remaining:
             self.setProperty('remaining', from_unicode('%02d' % remaining))
         if endtime:

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -63,9 +63,11 @@ class UpNext(WindowXMLDialog):
             self.setProperty('playcount', str(self.item.get('playcount', 0)))
 
     def prepare_progress_control(self):
-        self.progress_control = self.getControl(3014)
-        if self.progress_control is not None:
+        try:
+            self.progress_control = self.getControl(3014)
             self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
+        except RuntimeError:
+            pass
 
     def set_item(self, item):
         self.item = item
@@ -75,9 +77,11 @@ class UpNext(WindowXMLDialog):
 
     def update_progress_control(self, remaining=None, endtime=None):
         self.current_progress_percent = self.current_progress_percent - self.progress_step_size
-        self.progress_control = self.getControl(3014)
-        if self.progress_control is not None:
+        try:
+            self.progress_control = self.getControl(3014)
             self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
+        except RuntimeError:
+            pass
         if remaining:
             self.setProperty('remaining', from_unicode('%02d' % remaining))
         if endtime:

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -65,9 +65,10 @@ class UpNext(WindowXMLDialog):
     def prepare_progress_control(self):
         try:
             self.progress_control = self.getControl(3014)
-            self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
-        except RuntimeError:
+        except RuntimeError: # Occurs when skin does not include progress control
             pass
+        else:
+            self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
 
     def set_item(self, item):
         self.item = item
@@ -79,9 +80,11 @@ class UpNext(WindowXMLDialog):
         self.current_progress_percent = self.current_progress_percent - self.progress_step_size
         try:
             self.progress_control = self.getControl(3014)
-            self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
-        except RuntimeError:
+        except RuntimeError: # Occurs when skin does not include progress control
             pass
+        else:
+            self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member
+
         if remaining:
             self.setProperty('remaining', from_unicode('%02d' % remaining))
         if endtime:


### PR DESCRIPTION
Runtime exception in playbackmanager.py if neither next_up nor still_watching pages get shown because of early abort (e.g. user skipped directly to the end of the video).

Runtime exception when displaying either page if the skin does not have the progress control (ID 3014). Was checking for None on return of getControl() but this actually raises a RuntimeError exception if the control does not exist.