### PR TITLE
Add notification time offset

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -80,6 +80,9 @@ class Api:
         if self.data.get('notification_time'):
             return int(self.data.get('notification_time'))
 
+        if self.data.get('notification_time_offset'):
+            return total_time - int(self.data.get('notification_time_offset'))
+
         # Use a customized notification time, when configured
         if bool(get_setting('customAutoPlayTime') == 'true') and total_time:
             if total_time > 60 * 60:


### PR DESCRIPTION
This add the possibility to use directly the time offset of credits instead of relying from the final seconds

this should be resolve this issue: https://github.com/CastagnaIT/plugin.video.netflix/issues/414

i made a test and seem solved,
but is better if someother can test, @dagwieers ?

To test is needed to use netflix addon modified from this PR: https://github.com/CastagnaIT/plugin.video.netflix/pull/424

