### PR TITLE
Add `notification_offset` for Netflix

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -80,8 +80,12 @@ class Api:
         if self.data.get('notification_time'):
             return int(self.data.get('notification_time'))
 
+        # Some consumers send the offset when the credits start (e.g. Netflix)
+        if total_time and self.data.get('notification_offset'):
+            return total_time - int(self.data.get('notification_offset'))
+
         # Use a customized notification time, when configured
-        if bool(get_setting('customAutoPlayTime') == 'true') and total_time:
+        if total_time and bool(get_setting('customAutoPlayTime') == 'true'):
             if total_time > 60 * 60:
                 return int(get_setting('autoPlayTimeXL'))
             if total_time > 40 * 60:


### PR DESCRIPTION
Since this matches with Netflix's metadata better and changing the Netflix add-on is too hard at this time.

In the future it is likely other content providers may add this information in the same format as well.

This reimplements PR #146 since I couldn't modify the original PR.