### PR TITLE
Add System.Time and endtime to notification

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -27,6 +27,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "Als Nächstes"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "Endet um: $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Wiedergabe fortsetzen"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -26,6 +26,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr ""
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr ""
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -27,6 +27,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "À suivre"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "Fin à : $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Continuer à regarder"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -25,6 +25,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "Sljedeće"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "Završava u: $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Nastavite gledati"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -25,6 +25,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "Következő rész"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "Befejezési időpont: $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Lejátszás folytatása"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -26,6 +26,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "Prossimo"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "Termina alle: $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Continua a guardare"

--- a/resources/language/resource.language.ja_JP/strings.po
+++ b/resources/language/resource.language.ja_JP/strings.po
@@ -26,6 +26,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "次のエピソードまで"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "終了時間: $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "続いて観る"

--- a/resources/language/resource.language.ko_KR/strings.po
+++ b/resources/language/resource.language.ko_KR/strings.po
@@ -26,6 +26,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "다음 에피소드 시작까지"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "종료: $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "계속 봅니다."

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -25,6 +25,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "Volgende aflevering"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "Eindigt om: $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Verder kijken"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -25,6 +25,10 @@ msgctxt "#30008"
 msgid "Up Next"
 msgstr "Kolejny"
 
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "Koniec o: $INFO[Window.Property(endtime)]"
+
 msgctxt "#30010"
 msgid "Continue watching"
 msgstr "Kontynuuj oglądanie"

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -2,8 +2,7 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from datetime import datetime, timedelta
-from xbmc import getRegion, sleep
+from xbmc import sleep
 from api import Api
 from player import Player
 from playitem import PlayItem
@@ -91,7 +90,6 @@ class PlaybackManager:
             self.log('exit early because player is no longer running', 2)
             return False, False
         progress_step_size = calculate_progress_steps(total_time - play_time)
-        episode_runtime = episode.get('runtime') is not None
         next_up_page.set_item(episode)
         next_up_page.set_progress_step_size(progress_step_size)
         still_watching_page.set_item(episode)
@@ -127,18 +125,12 @@ class PlaybackManager:
                 break
 
             remaining = total_time - play_time
-            if episode_runtime:
-                end_time = total_time - play_time + episode.get('runtime')
-                end_time = datetime.now() + timedelta(seconds=end_time)
-                time_format = getRegion('time').replace(':%S', '')  # Strip off seconds
-                end_time = end_time.strftime(time_format).lstrip('0')  # Remove leading zero on all platforms
-            else:
-                end_time = None
+            runtime = episode.get('runtime')
             if not self.state.pause:
                 if showing_next_up_page:
-                    next_up_page.update_progress_control(remaining=remaining, endtime=end_time)
+                    next_up_page.update_progress_control(remaining=remaining, runtime=runtime)
                 elif showing_still_watching_page:
-                    still_watching_page.update_progress_control(remaining=remaining, endtime=end_time)
+                    still_watching_page.update_progress_control(remaining=remaining, runtime=runtime)
             sleep(100)
         return showing_next_up_page, showing_still_watching_page
 

--- a/resources/lib/script.py
+++ b/resources/lib/script.py
@@ -3,10 +3,12 @@
 ''' This is the actual Up Next API script '''
 
 from __future__ import absolute_import, division, unicode_literals
+from datetime import datetime, timedelta
 from math import ceil
 from xbmc import sleep
 from xbmcgui import WindowXMLDialog
-from utils import addon_path, get_setting, localize
+from statichelper import from_unicode
+from utils import addon_path, get_setting, localize, localize_time
 
 
 class TestPopup(WindowXMLDialog):
@@ -45,6 +47,7 @@ class TestPopup(WindowXMLDialog):
         self.setProperty('title', 'Garden of Bones')
         self.setProperty('tvshowtitle', 'Game of Thrones')
         self.setProperty('year', '2012')
+        self.setProperty('runtime', '50')
 
     def prepare_progress_control(self):
         self.progress_control = self.getControl(3014)
@@ -57,7 +60,8 @@ class TestPopup(WindowXMLDialog):
             return
         self.current_progress_percent -= 100 * wait / timeout
         self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member,useless-suppression
-        self.setProperty('remaining', '%02d' % ceil((timeout / 1000) * (self.current_progress_percent / 100)))
+        self.setProperty('remaining', from_unicode('%02d' % ceil((timeout / 1000) * (self.current_progress_percent / 100))))
+        self.setProperty('endtime', from_unicode(localize_time(datetime.now() + timedelta(seconds=50 * 60))))
 
     def onFocus(self, controlId):  # pylint: disable=invalid-name
         pass

--- a/resources/lib/stillwatching.py
+++ b/resources/lib/stillwatching.py
@@ -2,9 +2,11 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
+from datetime import datetime, timedelta
 from platform import machine
 from xbmcgui import WindowXMLDialog
 from statichelper import from_unicode
+from utils import localize_time
 
 ACTION_PLAYER_STOP = 13
 ACTION_NAV_BACK = 92
@@ -55,11 +57,12 @@ class StillWatching(WindowXMLDialog):
             self.setProperty('year', str(self.item.get('firstaired', '')))
             self.setProperty('rating', rating)
             self.setProperty('playcount', str(self.item.get('playcount', 0)))
+            self.setProperty('runtime', str(self.item.get('runtime', '')))
 
     def prepare_progress_control(self):
         try:
             self.progress_control = self.getControl(3014)
-        except RuntimeError: # Occurs when skin does not include progress control
+        except RuntimeError:  # Occurs when skin does not include progress control
             pass
         else:
             self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member,useless-suppression
@@ -70,19 +73,19 @@ class StillWatching(WindowXMLDialog):
     def set_progress_step_size(self, progress_step_size):
         self.progress_step_size = progress_step_size
 
-    def update_progress_control(self, remaining=None, endtime=None):
+    def update_progress_control(self, remaining=None, runtime=None):
         self.current_progress_percent = self.current_progress_percent - self.progress_step_size
         try:
             self.progress_control = self.getControl(3014)
-        except RuntimeError: # Occurs when skin does not include progress control
+        except RuntimeError:  # Occurs when skin does not include progress control
             pass
         else:
             self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member,useless-suppression
 
         if remaining:
             self.setProperty('remaining', from_unicode('%02d' % remaining))
-        if endtime:
-            self.setProperty('endtime', from_unicode(str(endtime)))
+        if runtime:
+            self.setProperty('endtime', from_unicode(localize_time(datetime.now() + timedelta(seconds=runtime))))
 
     def set_cancel(self, cancel):
         self.cancel = cancel

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -2,11 +2,12 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
+from datetime import datetime, timedelta
 from platform import machine
 from xbmc import Player
 from xbmcgui import WindowXMLDialog
 from statichelper import from_unicode
-from utils import get_setting, localize
+from utils import get_setting, localize, localize_time
 
 ACTION_PLAYER_STOP = 13
 ACTION_NAV_BACK = 92
@@ -61,11 +62,12 @@ class UpNext(WindowXMLDialog):
             self.setProperty('year', str(self.item.get('firstaired', '')))
             self.setProperty('rating', rating)
             self.setProperty('playcount', str(self.item.get('playcount', 0)))
+            self.setProperty('runtime', str(self.item.get('runtime', '')))
 
     def prepare_progress_control(self):
         try:
             self.progress_control = self.getControl(3014)
-        except RuntimeError: # Occurs when skin does not include progress control
+        except RuntimeError:  # Occurs when skin does not include progress control
             pass
         else:
             self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member,useless-suppression
@@ -76,19 +78,19 @@ class UpNext(WindowXMLDialog):
     def set_progress_step_size(self, progress_step_size):
         self.progress_step_size = progress_step_size
 
-    def update_progress_control(self, remaining=None, endtime=None):
+    def update_progress_control(self, remaining=None, runtime=None):
         self.current_progress_percent = self.current_progress_percent - self.progress_step_size
         try:
             self.progress_control = self.getControl(3014)
-        except RuntimeError: # Occurs when skin does not include progress control
+        except RuntimeError:  # Occurs when skin does not include progress control
             pass
         else:
             self.progress_control.setPercent(self.current_progress_percent)  # pylint: disable=no-member,useless-suppression
 
         if remaining:
             self.setProperty('remaining', from_unicode('%02d' % remaining))
-        if endtime:
-            self.setProperty('endtime', from_unicode(str(endtime)))
+        if runtime:
+            self.setProperty('endtime', from_unicode(localize_time(datetime.now() + timedelta(seconds=runtime))))
 
     def set_cancel(self, cancel):
         self.cancel = cancel

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals
 import sys
 import json
-from xbmc import executeJSONRPC, log as xlog, LOGDEBUG, LOGNOTICE
+from xbmc import executeJSONRPC, getRegion, log as xlog, LOGDEBUG, LOGNOTICE
 from xbmcaddon import Addon
 from xbmcgui import Window
 from statichelper import from_unicode, to_unicode
@@ -145,3 +145,9 @@ def get_global_setting(setting):
 def localize(string_id):
     ''' Return the translated string from the .po language files, optionally translating variables '''
     return ADDON.getLocalizedString(string_id)
+
+
+def localize_time(time):
+    """Localize time format"""
+    time_format = getRegion('time').replace(':%S', '')  # Strip off seconds
+    return time.strftime(time_format).lstrip('0')  # Remove leading zero on all platforms

--- a/resources/skins/default/1080i/script-upnext-stillwatching.xml
+++ b/resources/skins/default/1080i/script-upnext-stillwatching.xml
@@ -223,6 +223,32 @@
                         <texture colordiffuse="ddffffff">nextupicons/00.png</texture>
                         <animation effect="slide" end="13,-5" time="0" condition="true">Conditional</animation>
                     </control>
+                    <control type="group">
+                        <visible>!Window.IsVisible(extendedprogressdialog)</visible>
+                        <animation effect="fade" time="150">VisibleChange</animation>
+                        <control type="label">
+                            <font>font_clock</font>
+                            <shadowcolor>text_shadow</shadowcolor>
+                            <top>0</top>
+                            <right>20</right>
+                            <height>200</height>
+                            <width>600</width>
+                            <align>right</align>
+                            <label>$INFO[System.Time]</label>
+                        </control>
+                        <control type="label">
+                            <right>24</right>
+                            <top>74</top>
+                            <width>800</width>
+                            <height>100</height>
+                            <align>right</align>
+                            <itemgap>5</itemgap>
+                            <orientation>horizontal</orientation>
+                            <usecontrolcoords>true</usecontrolcoords>
+                            <label>$ADDON[service.upnext 30009]</label>
+                            <shadowcolor>text_shadow</shadowcolor>
+                        </control>
+                    </control>
                 </control>
             </control>
         </control>

--- a/resources/skins/default/1080i/script-upnext-upnext.xml
+++ b/resources/skins/default/1080i/script-upnext-upnext.xml
@@ -206,6 +206,32 @@
                         <texture colordiffuse="ddffffff">nextupicons/00.png</texture>
                         <animation effect="slide" end="13,-5" time="0" condition="true">Conditional</animation>
                     </control>
+                    <control type="group">
+                        <visible>!Window.IsVisible(extendedprogressdialog)</visible>
+                        <animation effect="fade" time="150">VisibleChange</animation>
+                        <control type="label">
+                            <font>font_clock</font>
+                            <shadowcolor>text_shadow</shadowcolor>
+                            <top>0</top>
+                            <right>20</right>
+                            <height>200</height>
+                            <width>600</width>
+                            <align>right</align>
+                            <label>$INFO[System.Time]</label>
+                        </control>
+                        <control type="label">
+                            <right>24</right>
+                            <top>74</top>
+                            <width>800</width>
+                            <height>100</height>
+                            <align>right</align>
+                            <itemgap>5</itemgap>
+                            <orientation>horizontal</orientation>
+                            <usecontrolcoords>true</usecontrolcoords>
+                            <label>$ADDON[service.upnext 30009]</label>
+                            <shadowcolor>text_shadow</shadowcolor>
+                        </control>
+                    </control>
                 </control>
             </control>
         </control>


### PR DESCRIPTION
This PR includes:
- Changes to the skin to add Time and next endtime
- New `endtime` window property

This fixes #81 

The implementation looks like this:
![screenshot023](https://user-images.githubusercontent.com/388198/72310270-9ebba480-3681-11ea-942f-4e940602ead9.png)

