### PR TITLE
Do not show "Ends at:" when endtime is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Int
 - Show current time and next endtime in notification (@dagwieers)
 - New translations for Brazilian, Czech, Greek, Japanese, Korean (@mediabrasiltv, @svetlemodry, @Twilight0, @Thunderbird2086)
 - New translations for Russian, Slovak, Spanish, Swedish (@vlmaksime, @matejmosko, @sagatxxx, @Sopor)
-- Translation updates to Croatian, German, Hungarian, Italian, Polish (@arvvoid, @tweimer, @frodo19, @EffeF, @notoco)
+- Translation updates to Croatian, French, German, Hungarian, Italian, Polish (@arvvoid, @zecakeh, @tweimer, @frodo19, @EffeF, @notoco)

--- a/addon.xml
+++ b/addon.xml
@@ -44,7 +44,7 @@ Många befintliga tillägg integreras redan med den här utanför lådan-tjänst
 - Show current time and next endtime in notification
 - New translations for Brazilian, Czech, Greek, Japanese, Korean
 - New translations for Russian, Slovak, Spanish, Swedish
-- Translation updates to Croatian, German, Hungarian, Italian, Polish
+- Translation updates to Croatian, French, German, Hungarian, Italian, Polish
         </news>
         <assets>
             <icon>resources/media/icon.png</icon>

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -150,4 +150,4 @@ def localize(string_id):
 def localize_time(time):
     """Localize time format"""
     time_format = getRegion('time').replace(':%S', '')  # Strip off seconds
-    return time.strftime(time_format).lstrip('0')  # Remove leading zero on all platforms
+    return time.strftime(time_format)

--- a/resources/skins/default/1080i/script-upnext-stillwatching.xml
+++ b/resources/skins/default/1080i/script-upnext-stillwatching.xml
@@ -247,6 +247,7 @@
                             <usecontrolcoords>true</usecontrolcoords>
                             <label>$ADDON[service.upnext 30009]</label>
                             <shadowcolor>text_shadow</shadowcolor>
+                            <visible>!String.IsEmpty(Window.Property(endtime))</visible>
                         </control>
                     </control>
                 </control>

--- a/resources/skins/default/1080i/script-upnext-upnext.xml
+++ b/resources/skins/default/1080i/script-upnext-upnext.xml
@@ -230,6 +230,7 @@
                             <usecontrolcoords>true</usecontrolcoords>
                             <label>$ADDON[service.upnext 30009]</label>
                             <shadowcolor>text_shadow</shadowcolor>
+                            <visible>!String.IsEmpty(Window.Property(endtime))</visible>
                         </control>
                     </control>
                 </control>


### PR DESCRIPTION
This PR includes:
- Avoid showing "Ends at:" when no endtime was available
- Do not strip leading zeroes as "0:34" becomes ":34"
- Small update to changelog (French was missing)