### PR TITLE
Restore "Ignore Playlist" option

### DIFF
--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -26,8 +26,12 @@ class PlaybackManager:
         ulog(msg, name=self.__class__.__name__, level=level)
 
     def launch_up_next(self):
-        playlist_item = True
+        playlist_item = True if get_setting('enablePlaylist') == "True" else False
         episode = self.play_item.get_next()
+        self.log('Playlist setting: %s' % playlist_item)
+        if episode and not playlist_item:
+            self.log('Playlist integration disabled', 2)
+            return
         if not episode:
             playlist_item = False
             episode = self.play_item.get_episode()
@@ -73,8 +77,11 @@ class PlaybackManager:
         # Signal to trakt previous episode watched
         event(message='NEXTUPWATCHEDSIGNAL', data=dict(episodeid=self.state.current_episode_id), encoding='base64')
         if playlist_item:
-            # Play playlist media
-            self.player.seekTime(self.player.getTotalTime())
+            try:
+                # Play playlist media
+                self.player.seekTime(self.player.getTotalTime())
+            except RuntimeError:
+                pass
         elif self.api.has_addon_data():
             # Play add-on media
             self.api.play_addon_item()

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -26,7 +26,7 @@ class PlaybackManager:
         ulog(msg, name=self.__class__.__name__, level=level)
 
     def launch_up_next(self):
-        playlist_item = True if get_setting('enablePlaylist') == "True" else False
+        playlist_item = bool(get_setting('enablePlaylist') == 'true')
         episode = self.play_item.get_next()
         self.log('Playlist setting: %s' % playlist_item)
         if episode and not playlist_item:

--- a/resources/lib/script.py
+++ b/resources/lib/script.py
@@ -50,7 +50,10 @@ class TestPopup(WindowXMLDialog):
         self.setProperty('runtime', '50')
 
     def prepare_progress_control(self):
-        self.progress_control = self.getControl(3014)
+        try:
+            self.progress_control = self.getControl(3014)
+        except:
+            self.progress_control = None
         if self.progress_control is None:
             return
         self.progress_control.setPercent(100.0)  # pylint: disable=no-member,useless-suppression

--- a/resources/lib/script.py
+++ b/resources/lib/script.py
@@ -53,8 +53,6 @@ class TestPopup(WindowXMLDialog):
         try:
             self.progress_control = self.getControl(3014)
         except:
-            self.progress_control = None
-        if self.progress_control is None:
             return
         self.progress_control.setPercent(100.0)  # pylint: disable=no-member,useless-suppression
 

--- a/resources/lib/script.py
+++ b/resources/lib/script.py
@@ -52,7 +52,7 @@ class TestPopup(WindowXMLDialog):
     def prepare_progress_control(self):
         try:
             self.progress_control = self.getControl(3014)
-        except:
+        except RuntimeError:
             return
         self.progress_control.setPercent(100.0)  # pylint: disable=no-member,useless-suppression
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -16,8 +16,7 @@
         <setting label="30619" type="slider" id="autoPlayTimeM" default="40" range="0,5,120" option="int" subsetting="true" visible="eq(-4,true)"/>
         <setting label="30621" type="slider" id="autoPlayTimeL" default="50" range="0,5,120" option="int" subsetting="true" visible="eq(-5,true)"/>
         <setting label="30623" type="slider" id="autoPlayTimeXL" default="60" range="0,5,120" option="int" subsetting="true" visible="eq(-6,true)"/>
-        <!-- Old unused settings -->
-        <setting label="30032" type="bool" id="enablePlaylist" visible="false" enable="false"/> <!-- To avoid log spam just disable setting -->
+        <setting label="30032" type="bool" id="enablePlaylist" default="false"/>
     </category>
     <category label="30700"> <!-- Expert -->
         <setting label="30703" type="bool" id="disableNextUp" default="false"/>


### PR DESCRIPTION
Restore the option to not show the pop-up when playing from a playlist.
This prevents a couple issues:
1. Breaking the playlist if the current show has further episodes.
2. Episodes continue playing regardless of the user choice to not continue watching on the pop-ups.