### PR TITLE
Avoid conflict with external players

### DIFF
--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -45,7 +45,7 @@ class UpNextMonitor(Monitor):
                 # Next Up is disabled
                 self.player.disable_tracking()
                 continue
-                
+
             if self.player.isExternalPlayer():
                 self.log('Up Next tracking stopped, external player detected', 2)
                 self.player.disable_tracking()
@@ -81,7 +81,7 @@ class UpNextMonitor(Monitor):
                 self.log('Up Next tracking stopped, failed player.getTime()', 2)
                 self.player.disable_tracking()
                 continue
- 
+
             notification_time = self.api.notification_time(total_time=total_time)
             if total_time - play_time > notification_time:
                 # Media hasn't reach notification time yet, waiting a bit longer...

--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -37,6 +37,10 @@ class UpNextMonitor(Monitor):
             if not self.player.is_tracking():
                 continue
 
+            if self.player.isExternalPlayer():
+                self.log('External Player detected...exiting', 2)
+                continue
+
             up_next_disabled = bool(get_setting('disableNextUp') == 'true')
             if bool(get_property('PseudoTVRunning') == 'True') or up_next_disabled:
                 continue

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -27,6 +27,7 @@ class PlaybackManager:
 
     def launch_up_next(self):
         if self.player.isExternalPlayer():
+            self.log('Error: External Player detected...exiting', 1)
             return
         playlist_item = bool(get_setting('enablePlaylist') == 'true')
         episode = self.play_item.get_next()

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -27,7 +27,7 @@ class PlaybackManager:
 
     def launch_up_next(self):
         if self.player.isExternalPlayer():
-            self.log('Error: External Player detected...exiting', 1)
+            self.log('Error: External player detected...exiting', 1)
             return
         playlist_item = bool(get_setting('enablePlaylist') == 'true')
         episode = self.play_item.get_next()

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -27,7 +27,7 @@ class PlaybackManager:
 
     def launch_up_next(self):
         if self.player.isExternalPlayer():
-            self.log('Error: External player detected...exiting', 1)
+            self.log('Error: External Player detected...exiting', 1)
             return
         playlist_item = bool(get_setting('enablePlaylist') == 'true')
         episode = self.play_item.get_next()

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -26,6 +26,8 @@ class PlaybackManager:
         ulog(msg, name=self.__class__.__name__, level=level)
 
     def launch_up_next(self):
+        if self.player.isExternalPlayer():
+            return
         playlist_item = bool(get_setting('enablePlaylist') == 'true')
         episode = self.play_item.get_next()
         self.log('Playlist setting: %s' % playlist_item)

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -26,9 +26,6 @@ class PlaybackManager:
         ulog(msg, name=self.__class__.__name__, level=level)
 
     def launch_up_next(self):
-        if self.player.isExternalPlayer():
-            self.log('Error: External Player detected...exiting', 1)
-            return
         playlist_item = bool(get_setting('enablePlaylist') == 'true')
         episode = self.play_item.get_next()
         self.log('Playlist setting: %s' % playlist_item)


### PR DESCRIPTION
Kodi can't track playback position for external players, so not only we can't tell when to show the pop-up, but when it is displayed (I'm guessing based on `playcountminimumtime` tag from `playercorefactory.xml` - [ref](https://kodi.wiki/view/External_players)) the external player might lose focus and stop playback (was my experience at least, ymmv).