### PR TITLE
Enqueue the next episode in the playlist

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -35,6 +35,21 @@ class Api:
     def play_kodi_item(episode):
         jsonrpc(method='Player.Open', id=0, params=dict(item=dict(episodeid=episode.get('episodeid'))))
 
+    def queue_next_item(self, episode):
+        next_item = {}
+        if not self.data:
+            next_item.update(episodeid=episode.get('episodeid'))
+        elif self.data.get('play_url'):
+            next_item.update(file=self.data.get('play_url'))
+        
+        if next_item:
+            jsonrpc(method='Playlist.Add', id=0, params=dict(playlistid=1, item=next_item))
+
+        return bool(next_item)
+
+    def reset_queue(self):
+        jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=0))
+
     def get_next_in_playlist(self, position):
         result = jsonrpc(method='Playlist.GetItems', params=dict(
             playlistid=1,

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -41,13 +41,14 @@ class Api:
             next_item.update(episodeid=episode.get('episodeid'))
         elif self.data.get('play_url'):
             next_item.update(file=self.data.get('play_url'))
-        
+
         if next_item:
             jsonrpc(method='Playlist.Add', id=0, params=dict(playlistid=1, item=next_item))
 
         return bool(next_item)
 
-    def reset_queue(self):
+    @staticmethod
+    def reset_queue():
         jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=0))
 
     def get_next_in_playlist(self, position):

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -16,7 +16,7 @@ class UpNextPlayer(Player):
         self.api = Api()
         self.state = State()
         self.monitor = Monitor()
-        Player.__init__(self)
+        Player.__init__(self, Player())
 
     def set_last_file(self, filename):
         self.state.last_file = filename

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -16,7 +16,7 @@ class UpNextPlayer(Player):
         self.api = Api()
         self.state = State()
         self.monitor = Monitor()
-        Player.__init__(self, Player())
+        Player.__init__(self)
 
     def set_last_file(self, filename):
         self.state.last_file = filename

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -30,13 +30,18 @@ class UpNextPlayer(Player):
     def disable_tracking(self):
         self.state.track = False
 
+    def reset_queue(self):
+        if self.state.queued:
+            self.api.reset_queue()
+            self.state.queued = False
+
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
         """Will be called when kodi starts playing a file"""
         self.monitor.waitForAbort(5)
         if not getCondVisibility('videoplayer.content(episodes)'):
             return
         self.state.track = True
-
+        self.reset_queue()
 
     def onPlayBackPaused(self):  # pylint: disable=invalid-name
         self.state.pause = True
@@ -46,15 +51,18 @@ class UpNextPlayer(Player):
 
     def onPlayBackStopped(self):  # pylint: disable=invalid-name
         """Will be called when user stops playing a file"""
+        self.reset_queue()
         self.api.reset_addon_data()
         self.state = State()  # Reset state
 
     def onPlayBackEnded(self):  # pylint: disable=invalid-name
         """Will be called when Kodi has ended playing a file"""
+        self.reset_queue()
         self.api.reset_addon_data()
         self.state = State()  # Reset state
 
     def onPlayBackError(self):  # pylint: disable=invalid-name
         """Will be called when when playback stops due to an error"""
+        self.reset_queue()
         self.api.reset_addon_data()
         self.state = State()  # Reset state

--- a/resources/lib/state.py
+++ b/resources/lib/state.py
@@ -20,3 +20,4 @@ class State:
         self.last_file = None
         self.track = False
         self.pause = False
+        self.queued = False

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -87,7 +87,7 @@ class Player:
         return
 
     def playnext(self):
-    ''' A stub implementation for the xbmc Player class playnext() method '''
+        ''' A stub implementation for the xbmc Player class playnext() method '''
         return
 
     def stop(self):

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -86,6 +86,10 @@ class Player:
         ''' A stub implementation for the xbmc Player class play() method '''
         return
 
+    def playnext(self):
+    ''' A stub implementation for the xbmc Player class playnext() method '''
+        return
+
     def stop(self):
         ''' A stub implementation for the xbmc Player class stop() method '''
         return


### PR DESCRIPTION
Will enqueue the next episode to the playlist in launch_popup() and, by default, will play local media and addon media (where play_url is provided) as per normal playlist handling method. Will use existing local and addon media playback methods if the next episode is not added to the playlist (not actually checking if playlist item was successfully added, files match, playlist size increased by one, etc. as it didn't seem necessary)

Note that call to self.player.seekTime() in launch_popup() never seemed to work properly (caused the player to seek and continue playing past the file end time) and I'm not sure why this method was used rather than simply skipping to the next playlist item using self.player.playnext(). In any case both methods are now utilised, without any apparent problems on my end, but this may be device/timing dependent.

Queue state is reset (previous playlist item is removed) in the player monitor in the appropriate event callbacks.

This fixes #139 