### PR TITLE
Fix queuing of next episode using playlist

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -51,6 +51,10 @@ class Api:
     def reset_queue():
         jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=0))
 
+    @staticmethod
+    def dequeue_next_item():
+        jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=1))
+
     def get_next_in_playlist(self, position):
         result = jsonrpc(method='Playlist.GetItems', params=dict(
             playlistid=1,

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -145,14 +145,20 @@ class PlaybackManager:
                 elif showing_still_watching_page:
                     still_watching_page.update_progress_control(remaining=remaining, runtime=runtime)
             sleep(100)
-        if next_up_page.is_cancel() and not playlist_item:
+
+        if not playlist_item:
+            self.handle_user_interaction(next_up_page, still_watching_page, episode)
+
+        return showing_next_up_page, showing_still_watching_page
+
+    def handle_user_interaction(self, next_up_page, still_watching_page, episode):
+        if next_up_page.is_cancel():
             # Playback of next episode was cancelled - dequeue the next episode
             self.api.dequeue_next_item()
             self.state.queued = False
-        if still_watching_page.is_still_watching() and not playlist_item:
+        elif still_watching_page.is_still_watching():
             # User is still watching - queue the next episode
             self.state.queued = self.api.queue_next_item(episode)
-        return showing_next_up_page, showing_still_watching_page
 
     def extract_play_info(self, next_up_page, showing_next_up_page, showing_still_watching_page, still_watching_page):
         if showing_next_up_page:

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -92,7 +92,7 @@ class PlaybackManager:
             # Play local media
             self.api.play_kodi_item(episode)
 
-    def show_popup_and_wait(self, episode, next_up_page, still_watching_page, playlist_item):
+    def show_popup_and_wait(self, episode, next_up_page, still_watching_page, playlist_item):  # pylint: disable=too-many-branches
         try:
             play_time = self.player.getTime()
             total_time = self.player.getTotalTime()
@@ -145,20 +145,14 @@ class PlaybackManager:
                 elif showing_still_watching_page:
                     still_watching_page.update_progress_control(remaining=remaining, runtime=runtime)
             sleep(100)
-
-        if not playlist_item:
-            self.handle_user_interaction(next_up_page, still_watching_page, episode)
-
-        return showing_next_up_page, showing_still_watching_page
-
-    def handle_user_interaction(self, next_up_page, still_watching_page, episode):
-        if next_up_page.is_cancel():
+        if next_up_page.is_cancel() and not playlist_item:
             # Playback of next episode was cancelled - dequeue the next episode
             self.api.dequeue_next_item()
             self.state.queued = False
-        elif still_watching_page.is_still_watching():
+        if still_watching_page.is_still_watching() and not playlist_item:
             # User is still watching - queue the next episode
             self.state.queued = self.api.queue_next_item(episode)
+        return showing_next_up_page, showing_still_watching_page
 
     def extract_play_info(self, next_up_page, showing_next_up_page, showing_still_watching_page, still_watching_page):
         if showing_next_up_page:

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -57,9 +57,11 @@ class UpNextPlayer(Player):
 
     def onPlayBackEnded(self):  # pylint: disable=invalid-name
         """Will be called when Kodi has ended playing a file"""
-        self.reset_queue()
-        self.api.reset_addon_data()
-        self.state = State()  # Reset state
+        if not self.state.queued:
+            # Reset if playback ended without the next episode being queued
+            self.reset_queue()
+            self.api.reset_addon_data()
+            self.state = State()  # Reset state
 
     def onPlayBackError(self):  # pylint: disable=invalid-name
         """Will be called when when playback stops due to an error"""


### PR DESCRIPTION
Fixes issues with queuing of next episode via playlist:

1. We should not reset state if an episode ends, triggering the onPlayBackEnded event, when we have the next episode queued.
2. We should queue the next episode when the "Up Next" dialog is presented, but dequeue the next episode if the user cancels playback of the next episode.
3. We should not queue the next episode when the "Still Watching?" dialog is presented until and unless the user indicates they are indeed still watching.