### PR TITLE
Add Kodi v17 compatibility

### DIFF
--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -7,7 +7,7 @@ from api import Api
 from playbackmanager import PlaybackManager
 from player import UpNextPlayer
 from statichelper import from_unicode
-from utils import decode_json, get_property, get_setting_bool, log as ulog
+from utils import decode_json, get_property, get_setting_bool, kodi_version_major, log as ulog
 
 
 class UpNextMonitor(Monitor):
@@ -46,7 +46,8 @@ class UpNextMonitor(Monitor):
                 self.player.disable_tracking()
                 continue
 
-            if self.player.isExternalPlayer():
+            # Method isExternalPlayer() was added in Kodi v18 onward
+            if kodi_version_major() >= 18 and self.player.isExternalPlayer():
                 self.log('Up Next tracking stopped, external player detected', 2)
                 self.player.disable_tracking()
                 continue

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -4,9 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals
 import sys
 import json
-from xbmc import (
-    executeJSONRPC, getInfoLabel, getRegion, log as xlog, LOGDEBUG, LOGINFO
-)
+from xbmc import executeJSONRPC, getInfoLabel, getRegion, log as xlog, LOGDEBUG, LOGINFO
 from xbmcaddon import Addon
 from xbmcgui import Window
 from statichelper import from_unicode, to_unicode
@@ -200,3 +198,13 @@ def localize_time(time):
     time_format = time_format.replace(':%S', '')
 
     return time.strftime(time_format)
+
+
+def kodi_version():
+    """Returns full Kodi version as string"""
+    return getInfoLabel('System.BuildVersion').split(' ')[0]
+
+
+def kodi_version_major():
+    """Returns major Kodi version as integer"""
+    return int(kodi_version().split('.')[0])


### PR DESCRIPTION
This avoids testing for Player.isExternalPlayer() on Kodi v17 which does not
support this.

This fixes #214 