### PR TITLE
Enable customAutoPlay by default and get rid of seekTime()

### DIFF
--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -80,16 +80,8 @@ class PlaybackManager:
         # Signal to trakt previous episode watched
         event(message='NEXTUPWATCHEDSIGNAL', data=dict(episodeid=self.state.current_episode_id), encoding='base64')
         if playlist_item or self.state.queued:
-            # Play playlist media, only seek/skip if media has not already played through
-            if should_play_non_default:
-                try:
-                    total_time = self.player.getTotalTime()
-                    if self.player.getTime() <= total_time * 95 / 100:
-                        #  Seek to near-end to avoid issues with inexact seeking in Kodi Player
-                        self.player.seekTime((total_time - 1) * 59 / 60)
-                except RuntimeError:
-                    pass
-                self.player.playnext()
+            # Play playlist media
+            self.player.playnext()
         elif self.api.has_addon_data():
             # Play add-on media
             self.api.play_addon_item()

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -80,13 +80,16 @@ class PlaybackManager:
         # Signal to trakt previous episode watched
         event(message='NEXTUPWATCHEDSIGNAL', data=dict(episodeid=self.state.current_episode_id), encoding='base64')
         if playlist_item or self.state.queued:
-            try:
-                # Play playlist media, only seek/skip if media has not already played through
-                if should_play_non_default:
-                    self.player.seekTime(self.player.getTotalTime())
-                    self.player.playnext()
-            except RuntimeError:
-                pass
+            # Play playlist media, only seek/skip if media has not already played through
+            if should_play_non_default:
+                try:
+                    total_time = self.player.getTotalTime()
+                    if self.player.getTime() <= total_time * 95 / 100:
+                        #  Seek to near-end to avoid issues with inexact seeking in Kodi Player
+                        self.player.seekTime((total_time - 1) * 59 / 60)
+                except RuntimeError:
+                    pass
+                self.player.playnext()
         elif self.api.has_addon_data():
             # Play add-on media
             self.api.play_addon_item()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,7 +10,7 @@
         <setting label="30605" type="bool" id="includeWatched" default="false"/>
         <setting label="30607" type="slider" id="playedInARow" default="3" range="0,1,15" option="int"/>
         <setting label="30609" type="lsep"/> <!-- Autoplay duration -->
-        <setting label="30611" type="bool" id="customAutoPlayTime" default="false"/>
+        <setting label="30611" type="bool" id="customAutoPlayTime" default="true"/>
         <setting label="30613" type="slider" id="autoPlaySeasonTime" default="30" range="0,5,120" option="int" subsetting="true" visible="eq(-1,false)"/>
         <setting label="30615" type="slider" id="autoPlayTimeXS" default="15" range="0,5,120" option="int" subsetting="true" visible="eq(-2,true)"/>
         <setting label="30617" type="slider" id="autoPlayTimeS" default="30" range="0,5,120" option="int" subsetting="true" visible="eq(-3,true)"/>


### PR DESCRIPTION
This PR includes:
- Enable `customAutoPlayTime` by default
- No longer skip to end

First of all, skipping the credits is not needed in the majority of cases, because the pop-up appears within the 90% default margin in Kodi.
    
Secondly, this seeking, when done using VOD add-ons, causes the player to exit before the next items is being played, so it doesn't give a nice user experience.

I no longer think this is a real problem, only for videos shorter than 5 mins (or 2.5 mins for customAutoPlay) this becomes an issue.
    
For Netflix it would mean that:
- For a 10 min episode would have issues if the credits shows earlier than 60 seconds.
- For a 30 min episode the credits should not appear before the last 180 seconds.
- For a 1 hour episode the credits should not appear before the last 360 seconds
    
This is all very unlikely. Only for short videos with long credits there might be a risk, but I think that is very theoretical.