### PR TITLE
Implement DEMO mode

### DIFF
--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Další epizoda"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Vývojář"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Otestovat vzhled uživatelského rozhraní"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -95,6 +95,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Nächste Episode"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -184,6 +192,10 @@ msgstr "Entwickler"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testen, wie die Benutzeroberfläche aussieht"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Επόμενο επεισόδιο"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Προγραμματιστής"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Δοκιμή του πως μοιάζει το περιβάλλον"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr ""
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -182,6 +190,10 @@ msgstr ""
 
 msgctxt "#30801"
 msgid "Test how the user interface looks"
+msgstr ""
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
 msgstr ""
 
 msgctxt "#30805"

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -94,6 +94,15 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Siguiente episodio"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
+
 # ## SETTINGS
 msgctxt "#30500"
 msgid "Interface"
@@ -182,6 +191,10 @@ msgstr "Desarrollador"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Prueba cómo se ve la interfaz de usuario"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -96,6 +96,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Prochain épisode"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -185,6 +193,10 @@ msgstr "Développeur"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Tester l’apparence de l’interface utilisateur"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -94,6 +94,15 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Sljedeća epizoda"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
+
 # ## SETTINGS
 msgctxt "#30500"
 msgid "Interface"
@@ -182,6 +191,10 @@ msgstr "Developer"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testirajte kako izgleda korisničko sučelje"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -93,6 +93,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Következő rész"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -182,6 +190,10 @@ msgstr "Fejlesztő"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Felhasználói felület kinézet tesztelése"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.in_hi/strings.po
+++ b/resources/language/resource.language.in_hi/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "अगला एपिसोड"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "विकासक"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "परीक्षण करें कि उपयोगकर्ता इंटरफ़ेस कैसा दिखता है"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -94,6 +94,15 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Prossimo Episodio"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
+
 # SETTINGS
 msgctxt "#30500"
 msgid "Interface"
@@ -182,6 +191,10 @@ msgstr "Sviluppatore"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testa come l'interfaccia utente appare"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "次のエピソード"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "デベロッパーモード"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "テストしたい通知ウィンドウ"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "다음 에피소드"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "개발자모드"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "어떤 알림창을 테스트하시렵니까?"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -93,6 +93,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Volgende aflevering"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr "[B]UP NEXT DEMO MODUS IS GEACTIVEERD[/B]"
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr "[I]Afleveringen springen automatisch naar het einde.[/I]"
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,9 +191,13 @@ msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Test hoe de gebruikersinterface er uit ziet"
 
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr "Activeer DEMO modus"
+
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"
-msgstr "Toon een upNext pop-up…"
+msgstr "Toon een UpNext pop-up…"
 
 msgctxt "#30807"
 msgid "Show an UpNextSimple pop-up…"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -93,6 +93,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Następny odcinek"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -182,6 +190,10 @@ msgstr "Deweloper"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testuj wygląd interfejsu"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Próximo Episódio"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Desenvolvedor"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Teste a aparência da interface do usuário"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -95,6 +95,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Următorul episod"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -184,6 +192,10 @@ msgstr "Dezvoltator"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testează cum arată interfața utilizator"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Следующая серия"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Для разработчика"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Проверьте, как выглядит пользовательский интерфейс"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
 "X-Generator: Poedit 2.2.4\n"
 
-# ## APPLICATION
+### APPLICATION
 msgctxt "#30006"
 msgid "Watch Now"
 msgstr "Pozerať teraz"
@@ -94,7 +94,16 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Ďalšia epizóda"
 
-# ## SETTINGS
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
+
+### SETTINGS
 msgctxt "#30500"
 msgid "Interface"
 msgstr "Rozhranie"
@@ -182,6 +191,10 @@ msgstr "Vývojár"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Otestuj ako vyzerá rozhranie"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Nästa avsnitt"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Utvecklare"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testa hur användargränssnittet ser ut"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/resources/lib/demo.py
+++ b/resources/lib/demo.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
+
+from __future__ import absolute_import, division, unicode_literals
+from xbmcgui import ControlLabel, getScreenHeight, getScreenWidth, Window
+from utils import localize, log as ulog
+
+
+class DemoOverlay():
+    def __init__(self, windowid):
+        self.window = Window(windowid)
+        self._demolabel = None
+        self.log('initialized')
+
+    def log(self, msg, level=2):
+        ulog(msg, name=self.__class__.__name__, level=level)
+
+    def show(self):
+        if self._demolabel is not None:
+            return
+        # FIXME: Using a different font does not seem to have much of an impact
+        self._demolabel = ControlLabel(0, getScreenHeight() // 4, getScreenWidth(), 100, localize(30060) + '\n' + localize(30061), font='font36_title', textColor='0xddee9922', alignment=0x00000002)
+        self.window.addControl(self._demolabel)
+        self.log('show', 0)
+
+    def hide(self):
+        if self._demolabel is None:
+            return
+        self.window.removeControl(self._demolabel)
+        self._demolabel = None
+        self.log('hide', 0)
+
+    def _close(self):
+        self.hide()
+        self.log('closed', 0)
+
+    def __del__(self):
+        self.hide()
+        self.log('destroy', 0)

--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -39,17 +39,20 @@ class UpNextMonitor(Monitor):
 
             if bool(get_property('PseudoTVRunning') == 'True'):
                 self.player.disable_tracking()
+                self.playback_manager.demo.hide()
                 continue
 
             if get_setting_bool('disableNextUp'):
                 # Next Up is disabled
                 self.player.disable_tracking()
+                self.playback_manager.demo.hide()
                 continue
 
             # Method isExternalPlayer() was added in Kodi v18 onward
             if kodi_version_major() >= 18 and self.player.isExternalPlayer():
                 self.log('Up Next tracking stopped, external player detected', 2)
                 self.player.disable_tracking()
+                self.playback_manager.demo.hide()
                 continue
 
             last_file = self.player.get_last_file()
@@ -58,9 +61,10 @@ class UpNextMonitor(Monitor):
             except RuntimeError:
                 self.log('Up Next tracking stopped, failed player.getPlayingFile()', 2)
                 self.player.disable_tracking()
+                self.playback_manager.demo.hide()
                 continue
 
-            if last_file and last_file == current_file:
+            if last_file and last_file == from_unicode(current_file):
                 # Already processed this playback before
                 continue
 
@@ -69,11 +73,13 @@ class UpNextMonitor(Monitor):
             except RuntimeError:
                 self.log('Up Next tracking stopped, failed player.getTotalTime()', 2)
                 self.player.disable_tracking()
+                self.playback_manager.demo.hide()
                 continue
 
             if total_time == 0:
                 self.log('Up Next tracking stopped, no file is playing', 2)
                 self.player.disable_tracking()
+                self.playback_manager.demo.hide()
                 continue
 
             try:
@@ -81,6 +87,7 @@ class UpNextMonitor(Monitor):
             except RuntimeError:
                 self.log('Up Next tracking stopped, failed player.getTime()', 2)
                 self.player.disable_tracking()
+                self.playback_manager.demo.hide()
                 continue
 
             notification_time = self.api.notification_time(total_time=total_time)
@@ -106,5 +113,6 @@ class UpNextMonitor(Monitor):
             self.log('Received data from sender %s is not JSON: %s' % (sender, data), 2)
             return
 
+        self.playback_manager.handle_demo()
         decoded_data.update(id='%s_play_action' % sender.replace('.SIGNAL', ''))
         self.api.addon_data_received(decoded_data, encoding=encoding)

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals
 from xbmc import sleep
 from api import Api
+from demo import DemoOverlay
 from player import Player
 from playitem import PlayItem
 from state import State
@@ -21,9 +22,22 @@ class PlaybackManager:
         self.play_item = PlayItem()
         self.state = State()
         self.player = Player()
+        self.demo = DemoOverlay(12005)
 
     def log(self, msg, level=2):
         ulog(msg, name=self.__class__.__name__, level=level)
+
+    def handle_demo(self):
+        if get_setting_bool('enableDemoMode'):
+            self.log('Up Next DEMO mode enabled, skipping automatically to the end', 0)
+            self.demo.show()
+            try:
+                total_time = self.player.getTotalTime()
+                self.player.seekTime(total_time - 15)
+            except RuntimeError as exc:
+                self.log('Failed to seekTime(): %s' % exc, 0)
+        else:
+            self.demo.hide()
 
     def launch_up_next(self):
         playlist_item = get_setting_bool('enablePlaylist')

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -37,7 +37,7 @@ class UpNextPlayer(Player):
 
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
         """Will be called when kodi starts playing a file"""
-        self.monitor.waitForAbort(5)
+        self.monitor.waitForAbort(2)
         if not getCondVisibility('videoplayer.content(episodes)'):
             return
         self.state.track = True

--- a/resources/lib/playitem.py
+++ b/resources/lib/playitem.py
@@ -36,6 +36,7 @@ class PlayItem:
             current_episode = self.api.handle_addon_lookup_of_current_episode()
             self.state.current_episode_id = current_episode.get('episodeid')
             if self.state.current_tv_show_id != current_episode.get('tvshowid'):
+                self.log('Change in TV show ID: last: %s / current: %s' % (self.state.current_tv_show_id, current_episode.get('tvshowid')), 2)
                 self.state.current_tv_show_id = current_episode.get('tvshowid')
                 self.state.played_in_a_row = 1
         return episode
@@ -53,10 +54,10 @@ class PlayItem:
             return
 
         item = result.get('result').get('item')
-        self.state.tv_show_id = item.get('tvshowid')
         if item.get('type') != 'episode':
             return
 
+        self.state.tv_show_id = item.get('tvshowid')
         if int(self.state.tv_show_id) == -1:
             current_show_title = item.get('showtitle').encode('utf-8')
             self.state.tv_show_id = self.api.showtitle_to_id(title=current_show_title)
@@ -72,5 +73,6 @@ class PlayItem:
         )
         self.state.current_episode_id = current_episode_id
         if self.state.current_tv_show_id != self.state.tv_show_id:
+            self.log('Change in TV show ID: last: %s / current: %s' % (self.state.current_tv_show_id, self.state.tv_show_id), 2)
             self.state.current_tv_show_id = self.state.tv_show_id
             self.state.played_in_a_row = 1

--- a/resources/lib/stillwatching.py
+++ b/resources/lib/stillwatching.py
@@ -34,7 +34,7 @@ class StillWatching(WindowXMLDialog):
         self.prepare_progress_control()
 
     def set_info(self):
-        episode_info = '%(season)sx%(episode)s.' % self.item
+        episode_info = '{season:0d}x{episode:0d}.'.format(**self.item)
         if self.item.get('rating') is None:
             rating = ''
         else:

--- a/resources/lib/upnext.py
+++ b/resources/lib/upnext.py
@@ -39,7 +39,7 @@ class UpNext(WindowXMLDialog):
             self.getControl(3013).setLabel(localize(30034))  # Close
 
     def set_info(self):
-        episode_info = '%(season)sx%(episode)s.' % self.item
+        episode_info = '{season:0d}x{episode:0d}.'.format(**self.item)
         if self.item.get('rating') is None:
             rating = ''
         else:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -24,6 +24,7 @@
     </category>
     <category label="30800"> <!-- Developer -->
         <setting label="30801" type="lsep"/> <!-- Test the GUI -->
+        <setting label="30803" type="bool" id="enableDemoMode" default="false"/>
         <setting label="30805" type="action" action="RunScript(service.upnext,test_window,script-upnext-upnext.xml)"/>
         <setting label="30807" type="action" action="RunScript(service.upnext,test_window,script-upnext-upnext-simple.xml)"/>
         <setting label="30809" type="action" action="RunScript(service.upnext,test_window,script-upnext-stillwatching.xml)"/>

--- a/tests/xbmcgui.py
+++ b/tests/xbmcgui.py
@@ -19,7 +19,7 @@ class Control:  # pylint: disable=too-few-public-methods
 class ControlLabel(Control):
     ''' A reimplementation of the xbmcgui ControlLabel class '''
 
-    def __init__(self):  # pylint: disable=super-init-not-called
+    def __init__(self, x, y, width, height, label='Foo bar', font=None, textColor=None, disabledColor=None, alignment=0, hasPath=False, angle=0):  # pylint: disable=super-init-not-called
         ''' A stub constructor for the xbmcgui ControlLabel class '''
 
     @staticmethod
@@ -200,6 +200,9 @@ class Window:
         ''' A stub constructor for the xbmcgui Window class '''
         return None
 
+    def addControl(self, pControl):
+        ''' A stub implementation for the xbmcgui Window class addControl() method '''
+
     def clearProperty(self):
         ''' A stub implementation for the xbmcgui Window class clearProperty() method '''
 
@@ -209,12 +212,15 @@ class Window:
     @staticmethod
     def getControl():
         ''' A stub implementation for the xbmcgui Window class getControl() method '''
-        return ControlLabel()
+        return ControlLabel(0, 0, 1920, 1080, 'StubLabel')
 
     @staticmethod
     def getProperty():
         ''' A stub implementation for the xbmcgui Window class getProperty() method '''
         return ''
+
+    def removeControl(self, pControl):
+        ''' A stub implementation for the xbmcgui Window class removeControl() method '''
 
     @staticmethod
     def setProperty(key, value):
@@ -239,3 +245,13 @@ class WindowXMLDialog(WindowXML):
     def __init__(self):
         ''' A stub constructor for the xbmcgui WindowXMLDialog class '''
         super(WindowXMLDialog, self).__init__()  # pylint: disable=super-with-arguments
+
+
+def getScreenHeight():
+    ''' A reimplementation of the xbmcgui getScreenHeight() function '''
+    return 1080
+
+
+def getScreenWidth():
+    ''' A reimplementation of the xbmcgui getScreenWidth() function '''
+    return 1920


### PR DESCRIPTION
The Developer section in the settings now has a DEMO mode switch.
If this is enabled, every playback will skip to the near-end to test the
behaviour of the UpNext add-on in high speed.

This allows testing e.g. StillWatching functionality.