### PR TITLE
Fix to prevent unwanted playback when using playlist queueing method

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -48,7 +48,14 @@ class Api:
         return bool(next_item)
 
     @staticmethod
+    def dequeue_next_item():
+        """Remove unplayed next item from video playlist"""
+        jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=1))
+        return False
+
+    @staticmethod
     def reset_queue():
+        """Remove previously played item from video playlist"""
         jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=0))
 
     def get_next_in_playlist(self, position):

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -108,11 +108,14 @@ class PlaybackManager:
         play_item_option_2 = (should_play_non_default and self.state.play_mode == 1)
         if not play_item_option_1 and not play_item_option_2:
             # play_next = False
-            # keep_playing = False
+            # keep_playing = next_up_page.is_cancel() if showing_next_up_page else still_watching_page.is_cancel()
+            # keep_playing = keep_playing and not get_setting_bool('stopAfterClose')
             # return play_next, keep_playing
-            # Don't play next file, and stop current file if not playback option selected
-            # Note that this will stop playback prematurely, even if stopAfterClose is not enabled
-            return False, False
+            # Don't play next file, and stop current file if no playback option selected
+            return False, (
+                (next_up_page.is_cancel() if showing_next_up_page else still_watching_page.is_cancel())
+                and not get_setting_bool('stopAfterClose')
+            )
 
         self.log('playing media episode', 2)
         # Signal to trakt previous episode watched

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -71,9 +71,11 @@ class PlaybackManager:
         no_play_count = episode.get('playcount') is None or episode.get('playcount') == 0
         include_play_count = True if self.state.include_watched else no_play_count
         if not include_play_count or self.state.current_episode_id == episode_id:
-            play_next = False
-            keep_playing = True
-            return play_next, keep_playing
+            # play_next = False
+            # keep_playing = True
+            # return play_next, keep_playing
+            # Don't play next file, but keep playing current file
+            return False, True
 
         if not playlist_item:
             self.state.queued = self.api.queue_next_item(episode)
@@ -95,18 +97,22 @@ class PlaybackManager:
                                                                               still_watching_page)
         if not self.state.track:
             self.log('exit launch_popup early due to disabled tracking', 2)
-            play_next = False
+            # play_next = False
+            # keep_playing = showing_next_up_page
+            # return play_next, keep_playing
+            # Don't play next file
             # Stop if Still Watching? popup was shown to prevent unwanted playback when using FF or skip
-            keep_playing = showing_next_up_page
-            return play_next, keep_playing
+            return False, showing_next_up_page
 
         play_item_option_1 = (should_play_default and self.state.play_mode == 0)
         play_item_option_2 = (should_play_non_default and self.state.play_mode == 1)
         if not play_item_option_1 and not play_item_option_2:
-            play_next = False
+            # play_next = False
+            # keep_playing = False
+            # return play_next, keep_playing
+            # Don't play next file, and stop current file if not playback option selected
             # Note that this will stop playback prematurely, even if stopAfterClose is not enabled
-            keep_playing = False
-            return play_next, keep_playing
+            return False, False
 
         self.log('playing media episode', 2)
         # Signal to trakt previous episode watched
@@ -123,9 +129,11 @@ class PlaybackManager:
             # Play local media
             self.api.play_kodi_item(episode)
 
-        play_next = True
-        keep_playing = True
-        return play_next, keep_playing
+        # play_next = True
+        # keep_playing = True
+        # return play_next, keep_playing
+        # Play next file, and keep playing current file
+        return True, True
 
     def show_popup_and_wait(self, episode, next_up_page, still_watching_page):
         try:

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -58,8 +58,10 @@ class UpNextPlayer(Player):
     def onPlayBackEnded(self):  # pylint: disable=invalid-name
         """Will be called when Kodi has ended playing a file"""
         self.reset_queue()
-        self.api.reset_addon_data()
-        self.state = State()  # Reset state
+        # Only reset state if not playing the next episode
+        if not self.state.playing_next:
+            self.api.reset_addon_data()
+            self.state = State()  # Reset state
 
     def onPlayBackError(self):  # pylint: disable=invalid-name
         """Will be called when when playback stops due to an error"""

--- a/resources/lib/state.py
+++ b/resources/lib/state.py
@@ -21,3 +21,4 @@ class State:
         self.track = False
         self.pause = False
         self.queued = False
+        self.playing_next = False


### PR DESCRIPTION
This is an interim fix to the unwanted playback problem, originally identified by @thebertster in #204 and also subsequently by others in #227.

Note that this wont fix all the issues that were identified in the discussion associated with #204, but should address the most common problem for most installations.