### PR TITLE
initial support for waiting till player is initialized

### DIFF
--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -70,7 +70,7 @@ class UpNextMonitor(Monitor):
             if last_file and last_file == from_unicode(current_file):
                 # Already processed this playback before
                 continue
-            elif not last_wait_file or last_wait_file != from_unicode(current_file):
+            if not last_wait_file or last_wait_file != from_unicode(current_file):
                 # Set initial time when waiting for player initialization started
                 start = time()
                 self.player.set_last_wait_file(from_unicode(current_file))
@@ -89,12 +89,12 @@ class UpNextMonitor(Monitor):
                 self.player.disable_tracking()
                 self.playback_manager.demo.hide()
                 continue
-            elif total_time == 0:
+            if total_time == 0:
                 # Sleep if not yet ready to retry later
                 sleep(0.5)
                 continue
-            else:
-                self.player.set_last_wait_file(None)
+
+            self.player.set_last_wait_file(None)
 
             try:
                 play_time = self.player.getTime()

--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -2,13 +2,13 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
+from time import time, sleep
 from xbmc import Monitor
 from api import Api
 from playbackmanager import PlaybackManager
 from player import UpNextPlayer
 from statichelper import from_unicode
 from utils import decode_json, get_property, get_setting_bool, kodi_version_major, log as ulog
-from time import time, sleep
 
 
 class UpNextMonitor(Monitor):

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -24,6 +24,12 @@ class UpNextPlayer(Player):
     def get_last_file(self):
         return self.state.last_file
 
+    def set_last_wait_file(self, filename):
+        self.state.last_wait_file = filename
+
+    def get_last_wait_file(self):
+        return self.state.last_wait_file
+
     def is_tracking(self):
         return self.state.track
 

--- a/resources/lib/state.py
+++ b/resources/lib/state.py
@@ -18,6 +18,7 @@ class State:
         self.tv_show_id = None
         self.played_in_a_row = 1
         self.last_file = None
+        self.last_wait_file = None
         self.track = False
         self.pause = False
         self.queued = False


### PR DESCRIPTION
Fixes #238 

This is just an example, which works with my case.

Probably, if you somehow manage to limit download speed for some stream, you can replicate this situation when player takes some time to get stream information and set up duration property.

