### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -14,10 +14,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: ${{ github.repository }}
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         sudo apt-get install xmlstarlet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8 ]
+        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 ]
     steps:
     - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
       uses: actions/checkout@v2


### PR DESCRIPTION
With the release of Python 3.9 we better test our code on the latest Python.