### PR TITLE
Fix for missing mediatype video info with addon video content

### DIFF
--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -116,3 +116,5 @@ class UpNextMonitor(Monitor):
         self.playback_manager.handle_demo()
         decoded_data.update(id='%s_play_action' % sender.replace('.SIGNAL', ''))
         self.api.addon_data_received(decoded_data, encoding=encoding)
+        self.player.enable_tracking()
+        self.player.reset_queue()

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -30,6 +30,9 @@ class UpNextPlayer(Player):
     def disable_tracking(self):
         self.state.track = False
 
+    def enable_tracking(self):
+        self.state.track = True
+
     def reset_queue(self):
         if self.state.queued:
             self.api.reset_queue()


### PR DESCRIPTION
Addresses https://github.com/xbmc/xbmc/issues/19378

Video mediatype may be discarded when a listItem VideoInfoTag is merged.

This can prevent UpNext from working with an addon, even if the addon sends the data required for UpNext to function, as UpNext checks the videoplayer.content(episodes) infobool for all video content, when this is only actually needed for library content.

Note that this should also be fixed for playlist content, however that change is a little bit more complicated and requires more significant modifications.

@Dis90 would you mind testing if this resolves the original problem you were having? 