### PR TITLE
Update Russian translation

### DIFF
--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -24,7 +24,7 @@ msgstr "Смотреть сейчас"
 
 msgctxt "#30008"
 msgid "Up Next"
-msgstr "Up Next"
+msgstr "Далее"
 
 msgctxt "#30009"
 msgid "Ends at: $INFO[Window.Property(endtime)]"


### PR DESCRIPTION
I fixed the "Up Next" header in the popup not being translated. I think there should be some clarification added that this is not the extension's title and that it should, in fact, be translated.