### PR TITLE
Make the played in a row setting a little clearer

### DIFF
--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -153,7 +153,7 @@ class PlaybackManager:
         self.log('played in a row %s' % self.state.played_in_a_row, 2)
         showing_next_up_page = False
         showing_still_watching_page = False
-        if not played_in_a_row_number or int(self.state.played_in_a_row) <= int(played_in_a_row_number):
+        if not played_in_a_row_number or int(self.state.played_in_a_row) < int(played_in_a_row_number):
             self.log('showing next up page as played in a row is %s' % self.state.played_in_a_row, 2)
             next_up_page.show()
             set_property('service.upnext.dialog', 'true')

--- a/resources/lib/playbackmanager.py
+++ b/resources/lib/playbackmanager.py
@@ -153,7 +153,7 @@ class PlaybackManager:
         self.log('played in a row %s' % self.state.played_in_a_row, 2)
         showing_next_up_page = False
         showing_still_watching_page = False
-        if int(self.state.played_in_a_row) <= int(played_in_a_row_number):
+        if not played_in_a_row_number or int(self.state.played_in_a_row) <= int(played_in_a_row_number):
             self.log('showing next up page as played in a row is %s' % self.state.played_in_a_row, 2)
             next_up_page.show()
             set_property('service.upnext.dialog', 'true')


### PR DESCRIPTION
Addresses https://github.com/im85288/service.upnext/issues/199#issuecomment-786277367 and #283

- Currently the comparison of played episodes is effectively made to played_in_a_row_number + 1, which means that a user would set the Number of episodes before "Still there?" query setting to 3, for example, but the Still Watching? popup would only show up if 4 episodes have played and the 5th episode was about to play. Now it will show up if 3 episodes have played.

- Currently there is no way to disable the Still Watching? popup. Now, changing the Number of episodes before "Still there?" query to 0 should disable it, and setting to 1 should make it appear all the time.