### PR TITLE
Fix SonarCloud integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           -Dsonar.projectKey=im85288_service.upnext
           -Dsonar.sources=resources/lib/
           -Dsonar.tests=tests/
+          -Dsonar.python.coverage.reportPaths=coverage.xml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
@im85288 - I noticed that a number of the existing workflows were failing. Have fixed most of them up, but the SonarCloud integration looks like it will need a new user authorisation token to be created.

You will need to go to https://sonarcloud.io/account/security to (re)create the user token.

Then go to https://github.com/im85288/service.upnext/settings/secrets/actions and create a new repository secret named `SONAR_TOKEN` with the secret set to the newly created user token.